### PR TITLE
取消塔罗尼克神图标记

### DIFF
--- a/JailBreak/addons/sourcemod/configs/mapdata.kv
+++ b/JailBreak/addons/sourcemod/configs/mapdata.kv
@@ -782,13 +782,13 @@
 	}
 	"jb_tacoroonies_v2_opt"
 	{
-		"m_Description"		"[神]塔克罗尼"
+		"m_Description"		"塔克罗尼"
 		"m_CertainTimes"		"all"
 		"m_Price"		"50"
 		"m_PricePartyBlock"		"3000"
 		"m_MinPlayers"		"0"
 		"m_MaxPlayers"		"0"
-		"m_MaxCooldown"		"15"
+		"m_MaxCooldown"		"30"
 		"m_NominateOnly"		"0"
 		"m_VipOnly"		"0"
 		"m_AdminOnly"		"0"


### PR DESCRIPTION
因暴动道具原因取消塔罗尼克神图标记