### PR TITLE
时空之轮翻译和塔卡拉最大倒计时修改

### DIFF
--- a/ZombiEscape/addons/sourcemod/configs/console_t/ze_chrono_trigger_b3_fix5.txt
+++ b/ZombiEscape/addons/sourcemod/configs/console_t/ze_chrono_trigger_b3_fix5.txt
@@ -3,492 +3,507 @@
 
     "***Player has picked WATER***"
     {
-        "chi" "** **"
+        "chi" "**水神器被拾取**"
     }
 
     "***Recharge: 60 seconds.***"
     {
-        "chi" "** **"
+        "chi" "**传送阵60秒**"
     }
 
     "*** Defend for 20 seconds aboard the bridge! ***"
     {
-        "chi" "** **"
+        "chi" "**在大桥上守住20秒!**"
     }
 
     "*** Defend for 10 seconds aboard the bridge! ***"
     {
-        "chi" "** **"
+        "chi" "**还剩10秒,坚持住!**"
     }
 
     "*** Defend for 5 seconds aboard the bridge! ***"
     {
-        "chi" "** **"
+        "chi" "** 还有5秒,开枪丢雷!!**"
     }
 
     "*** Dalton: We will meet again... ***"
     {
-        "chi" "** **"
+        "chi" "**道尔顿:我们还会再见面的...**"
     }
 
     "*** The mist has disappeared! ***"
     {
-        "chi" "** **"
+        "chi" "**雾消失了!**"
     }
 
     "*** Dalton uses: Hexagon Mist! Jump! ***"
     {
-        "chi" "** **"
+        "chi" "**道尔顿施法:Mist!跳起来! **"
     }
 
     "*** The mist has disappeared! ***"
     {
-        "chi" "** **"
+        "chi" "**Mist消失了!**"
     }
 
     "*** Dalton uses: Hexagon Mist! Crouch! ***"
     {
-        "chi" "** **"
+        "chi" "**道尔顿施法:Mist!蹲下!**"
     }
 
     "*** Dalton uses: Chaotic Zone! Get away from the zombies! ***"
     {
-        "chi" "** **"
+        "chi" "**道尔顿施法:召唤僵尸 拖住它们!**"
     }
 
     "*** Dalton: You won't survive this! ***"
     {
-        "chi" "** **"
+        "chi" "**道尔顿:你活不下去的!**"
     }
 
     "*** Dalton: Say goodbye! ***"
     {
-        "chi" "** **"
+        "chi" "**道尔顿:该说再见了!**"
     }
 
     "*** Dalton: No! I can't be defeated now! ***"
     {
-        "chi" "** **"
+        "chi" "**道尔顿:不!我现在还不能倒下!**"
     }
 
     "*** Dalton: Not when immortality is so close to hand. ***"
     {
-        "chi" "** **"
+        "chi" "**道尔顿:永生离我如此接近 哎.**"
     }
 
     "*** Dalton: We will meet again. ***"
     {
-        "chi" "** **"
+        "chi" "**道尔顿:我们会再次见面的.**"
     }
 
     "*** Defend for 20 seconds! ***"
     {
-        "chi" "** **"
+        "chi" "**防守20秒!**"
     }
 
     "*** Defend for 10 seconds! ***"
     {
-        "chi" "** **"
+        "chi" "**防守10秒!**"
+        "blocked"
     }
 
     "*** Defend for 5 seconds! ***"
     {
-        "chi" "** **"
+        "chi" "**防守5秒!**"
+        "blocked"
     }
 
     "*** Stage 2 has been completed! ***"
     {
-        "chi" "** **"
+        "chi" "**第二阶段已经完成!**"
     }
 
     "*** Dalton: I've been... defeated? ***"
     {
-        "chi" "** **"
+        "chi" "**道尔顿:我被...打败了?**"
     }
 
     "*** Dalton: Not yet. I still have one more thing up my sleeve. ***"
     {
-        "chi" "** **"
+        "chi" "**道尔顿:不!还没有!我还有件事要做!**"
     }
 
     "*** Dalton uses: Omega Flare! Dodge the laser! ***"
     {
-        "chi" "** **"
+        "chi" "**道尔顿施法:欧米茄之光!**"
     }
 
     "*** Dalton uses: Omega Flare! Dodge the laser! ***"
     {
-        "chi" "** **"
+        "chi" "**道尔顿施法:欧米茄之光!快躲开!**"
     }
 
     "*** Dalton uses: Omega Flare! Dodge the laser! ***"
     {
-        "chi" "** **"
+        "chi" "**道尔顿施法:欧米茄之光!快躲开!**"
     }
 
     "*** Dalton: So you finally decided to show up. ***"
     {
-        "chi" "** **"
+        "chi" "**道尔顿:最终你还是来了.**"
     }
 
     "*** Dalton: I let the Prophet go, knowing he'd mess up sooner or later. ***"
     {
-        "chi" "** **"
+        "chi" "**道尔顿:我让先知提前走了,因为我知道她迟早会搞砸.**"
     }
 
     "*** Dalton: But I've no use for you anymore. ***"
     {
-        "chi" "** **"
+        "chi" "**道尔顿:但我已不再需要你了.**"
     }
 
     "*** Dalton: You're history!. ***"
     {
-        "chi" "** **"
+        "chi" "**道尔顿:你已经成了历史!**"
     }
 
     "*** Dalton uses: Vortex! Get away from the middle! ***"
     {
-        "chi" "** **"
+        "chi" "**道尔顿施法:大漩涡!远离中间!**"
     }
 
     "*** The vortex has disappeared! ***"
     {
-        "chi" "** **"
+        "chi" "**大旋涡消失了!**"
     }
 
     "*** Dalton uses: Vortex! Get away from the sides! ***"
     {
-        "chi" "** **"
+        "chi" "**道尔顿施法:旋涡!远离左右俩边!**"
     }
 
     "*** The vortex has disappeared! ***"
     {
-        "chi" "** **"
+        "chi" "**旋涡消失了!**"
     }
 
     "*** Dalton uses: Hallation ***"
     {
-        "chi" "** **"
+        "chi" "**道尔顿施法:幻觉**"
     }
 
     "*** Dalton uses: Hallation ***"
     {
-        "chi" "** **"
+        "chi" "**道尔顿施法:幻觉**"
     }
 
     "*** Dalton uses: Hallation ***"
     {
-        "chi" "** **"
+        "chi" "**道尔顿施法:幻觉**"
     }
 
     "*** Dalton uses: Hallation ***"
     {
-        "chi" "** **"
+        "chi" "**道尔顿施法:幻觉**"
     }
 
     "*** Dalton uses: Teleportation! Get away from the middle! ***"
     {
-        "chi" "** **"
+        "chi" "**道尔顿施法:心灵传送!远离中场!**"
     }
 
     "*** Barrier 1 breaking in 15 seconds.. ***"
     {
-        "chi" "** **"
+        "chi" "**屏障一将在15秒后被打破**"
     }
 
     "*** Barrier 2 breaking in 15 seconds.. ***"
     {
-        "chi" "** **"
+        "chi" "**屏障二将在15秒后被打破**"
     }
 
     "*** Barrier 3 breaking in 15 seconds.. ***"
     {
-        "chi" "** **"
+        "chi" "**屏障三将在15秒后被打破**"
     }
 
     "Zombies teleporting in 5 seconds."
     {
-        "chi" "** **"
+        "chi" "**僵尸5秒后传送**"
     }
 
     "Barrier one breaking in 20 seconds."
     {
-        "chi" "** **"
+        "chi" "**一号障碍20秒后破碎**"
     }
 
     "Barrier one breaking in 5 seconds."
     {
-        "chi" "** **"
+        "chi" "**一号障碍5秒后破碎**"
+        "blocked"
     }
 
     "Barrier two breaking in 20 seconds."
     {
-        "chi" "** **"
+        "chi" "**二号障碍20秒后破碎**"
     }
 
     "Barrier two breaking in 5 seconds."
     {
-        "chi" "** **"
+        "chi" "**二号障碍5秒后破碎**"
+        "blocked"
     }
 
     "*** Temple doors will open in 30 seconds. ***"
     {
-        "chi" "** **"
+        "chi" "**神庙大门将在30秒后开启**"
     }
 
     "*** Temple doors will open in 10 seconds. ***"
     {
-        "chi" "** **"
+        "chi" "**神庙大门将在10秒后开启**"
+        "blocked"
     }
 
     "*** Temple doors will open in 5 seconds. ***"
     {
-        "chi" "** **"
+        "chi" "**神庙大门将在5秒后开启**"
+        "blocked"
     }
 
     "*** The door is open, escape! ***"
     {
-        "chi" "** **"
+        "chi" "**门开了!**"
     }
 
     "*** ADMIN HAS SWITCHED TO LEVEL 1.... ***"
     {
-        "chi" "** **"
+        "chi" "**管理员将关卡调成了第一关**"
     }
 
     "*** ADMIN HAS SWITCHED TO LEVEL 2.... ***"
     {
-        "chi" "** **"
+        "chi" "**管理员将关卡调成了第二关**"
     }
 
     "*** So you were able to escape... ***"
     {
-        "chi" "** **"
+        "chi" "**所以你得以逃脱...**"
     }
 
     "*** The Prophet was right... ***"
     {
-        "chi" "** **"
+        "chi" "**也许先知是对的...**"
     }
 
     "*** You must be stopped! ***"
     {
-        "chi" "** **"
+        "chi" "**必须阻止你!**"
     }
 
     "*** Teleporter activating in 5 seconds. ***"
     {
-        "chi" "** **"
+        "chi" "**传送将在5秒内启动**"
+        "blocked"
     }
 
     "*** Teleporter activating in 15 seconds. ***"
     {
-        "chi" "** **"
+        "chi" "**传送将在15秒内启动**"
+        "blocked"
     }
 
     "*** Teleporter activating in 25 seconds. ***"
     {
-        "chi" "** **"
+        "chi" "**传送将在25秒内启动**"
     }
 
     "*** Bridge spawning in 20 seconds... ***"
     {
-        "chi" "** **"
+        "chi" "**桥20秒后开启**"
     }
 
     "*** Bridge spawning in 10 seconds... ***"
     {
-        "chi" "** **"
+        "chi" "**桥10秒后开启**"
+        "blocked"
     }
 
     "*** Barrier 1 breaking in 20 seconds... ***"
     {
-        "chi" "** **"
+        "chi" "**一号障碍20秒后破碎**"
     }
 
     "*** Barrier 1 breaking in 10 seconds... ***"
     {
-        "chi" "** **"
+        "chi" "**一号障碍10秒后破碎**"
     }
 
     "*** Barrier 2 breaking in 10 seconds... ***"
     {
-        "chi" "** **"
+        "chi" "**二号障碍10秒后破碎**"
     }
 
     "*** Zombies teleporting in 3 seconds.... ***"
     {
-        "chi" "** **"
+        "chi" "**僵尸3秒后传送...**"
     }
 
     "*** Security System uses: Gravity ***"
     {
-        "chi" "** **"
+        "chi" "**防卫系统:重力**"
     }
 
     "*** Security System uses: Reversal ***"
     {
-        "chi" "** **"
+        "chi" "**防卫系统:二极反转**"
     }
 
     "*** Security System uses: Delta Attack ***"
     {
-        "chi" "** **"
+        "chi" "**防卫系统:三位一体!**"
     }
 
     "*** Stage 1 Completed! ***"
     {
-        "chi" "** **"
+        "chi" "**第一阶段完成!地图翻译:小彩旗**"
     }
 
     "*** The Security System has been defeated. ***"
     {
-        "chi" "** **"
+        "chi" "**防卫系统被破坏了.**"
     }
 
     "*** ALERT! SELF DESTRUCT MODE INITIATING***"
     {
-        "chi" "** **"
+        "chi" "**警告!自毁模块已启动!**"
     }
 
     "*** Hurry, get in the teleporter! ***"
     {
-        "chi" "** **"
+        "chi" "**走,前往传送器!**"
     }
 
     "*** Security System uses: Reduction ***"
     {
-        "chi" "** **"
+        "chi" "**防卫系统:减少**"
     }
 
     "*** Teleporter active! ***"
     {
-        "chi" "** **"
+        "chi" "**传送器启动**"
     }
 
     "*** Teleporter activating in 20 seconds. ***"
     {
-        "chi" "** **"
+        "chi" "**传送器将在20秒后启动.**"
+        "blocked"
     }
 
     "*** Teleporter activating in 30 seconds. ***"
     {
-        "chi" "** **"
+        "chi" "**传送器将在30秒后启动.**"
+        "blocked"
     }
 
     "*** Teleporter activating in 10 seconds. ***"
     {
-        "chi" "** **"
+        "chi" "**传送器将在10秒后启动.**"
+        "blocked"
     }
 
     "*** Teleporter activating in 5 seconds. ***"
     {
-        "chi" "** **"
+        "chi" "**传送器将在5秒后启动.**"
+        "blocked"
     }
 
     "*** Teleporter activating in 35 seconds. ***"
     {
-        "chi" "** **"
+        "chi" "**传送器将在35秒后启动.**"
     }
 
     "*** Zombies teleporting in 3 seconds... ***"
     {
-        "chi" "** **"
+        "chi" "**僵尸3秒后传送**"
     }
 
     "*** Stay away from the teleporter as it activates. ***"
     {
-        "chi" "** **"
+        "chi" "**远离传送器，你会死的哦.**"
     }
 
     "*** The temple is locked? ***"
     {
-        "chi" "** **"
+        "chi" "**神庙被上锁了?**"
     }
 
     "*** Defend until something happens. ***"
     {
-        "chi" "** **"
+        "chi" "**守株待兔.**"
     }
 
     "*** .... ***"
     {
-        "chi" "** **"
+        "chi" "**....**"
     }
 
     "*** The door is open, fall back!. ***"
     {
-        "chi" "** **"
+        "chi" "**门开了,退后!.**"
     }
 
     "*** Zombies are teleporting in 3 seconds. ***"
     {
-        "chi" "** **"
+        "chi" "**僵尸3秒传送**"
     }
 
     "*** The door will be closing in 5 seconds.... ***"
     {
-        "chi" "** **"
+        "chi" "**大门5秒后关闭**"
     }
 
     "*** Lucca: This doesn't look like Zeal Palace. ***"
     {
-        "chi" "** **"
+        "chi" "**Lucca:这不像热情宫殿.**"
     }
 
     "*** Lucca: With this machine in the middle, I'd almost say it was ***"
     {
-        "chi" "** **"
+        "chi" "**Lucca:有了这台机器,我差点说是..**"
     }
 
     "*** ALERT: HUMANS DETECTED IN THE SECURITY SYSTEM ***"
     {
-        "chi" "** **"
+        "chi" "**警告!防卫系统发现敌人**"
     }
 
     "*** PREPARE TO BE ELIMINATED ***"
     {
-        "chi" "** **"
+        "chi" "**准备被淘汰吧**"
     }
 
     "*** Security System used: Terminate ***"
     {
-        "chi" "** **"
+        "chi" "**防卫系统:终止**"
     }
 
     "*** ze_Chrono_Trigger. ***"
     {
-        "chi" "** **"
+        "chi" "**计时器已触发.地图翻译:小彩旗**"
     }
 
     "*** Teleporter activating in 25 seconds. ***"
     {
-        "chi" "** **"
+        "chi" "**传送器25秒后启动.**"
     }
 
     "*** Teleporter activating in 15 seconds. ***"
     {
-        "chi" "** **"
+        "chi" "**传送器15秒后启动.**"
+        "blocked"
     }
 
     "*** Teleporter activating in 5 seconds. ***"
     {
-        "chi" "** **"
+        "chi" "**传送器5秒后启动.**"
+        "blocked"
     }
 
     "*** Teleporter active! ***"
     {
-        "chi" "** **"
+        "chi" "**传送器启动.**"
     }
 
     "*** Requesting access from Zeal Palace. ***"
     {
-        "chi" "** **"
+        "chi" "**请从热情宫殿进入.**"
     }
 
     "*** Access granted. ***"
     {
-        "chi" "** **"
+        "chi" "**已授权访问权限**"
     }
 
 }

--- a/ZombiEscape/addons/sourcemod/configs/console_t/ze_chrono_trigger_b3_fix5.txt
+++ b/ZombiEscape/addons/sourcemod/configs/console_t/ze_chrono_trigger_b3_fix5.txt
@@ -28,7 +28,7 @@
 
     "*** Dalton: We will meet again... ***"
     {
-        "chi" "**道尔顿:我们还会再见面的...**"
+        "chi" "**道尔顿:我们还会再见面的..**"
     }
 
     "*** The mist has disappeared! ***"

--- a/ZombiEscape/cfg/sourcemod/map-configs/ze_tkara_v4_3.cfg
+++ b/ZombiEscape/cfg/sourcemod/map-configs/ze_tkara_v4_3.cfg
@@ -277,7 +277,7 @@ ze_speedmod_prefab_zombi "300"
 // 说  明: 最大倒计时时间<超过将转换为chat> (秒)
 // 最小值: 5.0
 // 最大值: 3600.0
-ze_maptext_maxcountdown "90"
+ze_maptext_maxcountdown "180"
 
 // 说  明: 文本在Hud上停留的时间 (秒)
 // 最小值: 1.0


### PR DESCRIPTION
添加时空之轮翻译
修改塔卡拉地下基地最大倒计时参数调整为180秒
原因是堡垒路线的倒计时为136秒，参数90秒无法正常显示。