### PR TITLE
幸存者参数调整

### DIFF
--- a/ZombiEscape/cfg/sourcemod/map-configs/ze_survivors_p2.cfg
+++ b/ZombiEscape/cfg/sourcemod/map-configs/ze_survivors_p2.cfg
@@ -52,7 +52,7 @@ mcr_map_extend_times "2"
 // 说  明: 坠落伤害 (%)
 // 最小值: 0.0
 // 最大值: 3.0
-sv_falldamage_scale "0"
+sv_falldamage_scale "1"
 
 // 说  明: 第三人称视角控制 (开关)
 // 最小值: 0
@@ -327,7 +327,7 @@ ze_weapons_spawn_decoy "1"
 // 说  明: 每局开始时补给的血针数量 (支)
 // 最小值: 0
 // 最大值: 1
-ze_weapons_spawn_healshot "0"
+ze_weapons_spawn_healshot "1"
 
 // 说  明: 每局最多可购买的高爆数量 (个)
 // 最小值: -1


### PR DESCRIPTION
由于叠伤BUG,导致部分玩家出现双倍扣血,雪地关卡不掉人路程过一半的时候有叠伤的玩家无法存活到飞机残骸处,尝试过各种办法,所以申请一根血针,为了平衡性,开启叠伤,增强了其他关卡的可玩性