### PR TITLE
平衡地图参数

### DIFF
--- a/ZombiEscape/cfg/sourcemod/map-configs/ze_the_curse_of_blackwater_v6b.cfg
+++ b/ZombiEscape/cfg/sourcemod/map-configs/ze_the_curse_of_blackwater_v6b.cfg
@@ -26,7 +26,7 @@ mp_roundtime "60.0"
 // 说  明: 地图等级 (1-6)
 // 最小值: 1
 // 最大值: 6
-rank_ze_map_tier "3"
+rank_ze_map_tier "4"
 
 
 ///
@@ -96,17 +96,17 @@ zr_respawn_delay "5.0"
 // 说  明: 全局击退系数 (%)
 // 最小值: 0.1
 // 最大值: 1.5
-zr_knockback_multi "1.3"
+zr_knockback_multi "1.4"
 
 // 说  明: 空中击退系数 (%)
 // 最小值: 0.1
 // 最大值: 1.5
-zr_classes_csgo_knockback_airmultiplier "0.35"
+zr_classes_csgo_knockback_airmultiplier "0.6"
 
 // 说  明: 人类传送 (次)
 // 最小值: 0
 // 最大值: 3
-zr_ztele_max_human "1"
+zr_ztele_max_human "0"
 
 // 说  明: 僵尸传送 (次)
 // 最小值: 0
@@ -121,27 +121,27 @@ zr_ztele_max_zombie "1"
 // 说  明: 伤害与金钱转化比例 ($)
 // 最小值: 0.0
 // 最大值: 30.0
-ze_damage_zombie_cash "0.7"
+ze_damage_zombie_cash "0.8"
 
 // 说  明: 伤害云点转化比例 (云点)
 // 最小值: 5000.0
 // 最大值: 999999.0
-ze_damage_rank_points "18000"
+ze_damage_rank_points "20000"
 
 // 说  明: 伤害积分转化比例 (积分)
 // 最小值: 5000.0
 // 最大值: 999999.0
-ze_damage_shop_credit "20000"
+ze_damage_shop_credit "24000"
 
 // 说  明: 通关所获得的积分 (积分)
 // 最小值: 0
 // 最大值: 30
-ze_credits_pass_round "4"
+ze_credits_pass_round "5"
 
 // 说  明: 通关获得多少云点<人类>
 // 最小值: 0
 // 最大值: 30
-rank_ze_win_points_humans "6"
+rank_ze_win_points_humans "10"
 
 
 ///
@@ -281,7 +281,7 @@ ze_maptext_textholdtime "8.0"
 // 说  明: 高爆持续时间<燃烧模式为燃烧时间, 减速模式为减速时间, 击退模式无效> (秒)
 // 最小值: 0.0
 // 最大值: 60.0
-ze_grenade_nade_duration "1.0"
+ze_grenade_nade_duration "1.2"
 
 // 说  明: 高爆击退模式的击退力度 (Unit)
 // 最小值: 0.0
@@ -306,7 +306,7 @@ ze_weapons_startmoney "8000"
 // 说  明: 每局最大可购买的Awp数量 (把)
 // 最小值: 0
 // 最大值: 64
-ze_weapons_awp_counts "0"
+ze_weapons_awp_counts "1"
 
 // 说  明: 每局开始时补给的高爆数量 (个)
 // 最小值: 0
@@ -331,22 +331,22 @@ ze_weapons_spawn_healshot "0"
 // 说  明: 每局最多可购买的高爆数量 (个)
 // 最小值: -1
 // 最大值: 15
-ze_weapons_round_hegrenade "5"
+ze_weapons_round_hegrenade "7"
 
 // 说  明: 每局最多可购买的火瓶数量 (个)
 // 最小值: -1
 // 最大值: 10
-ze_weapons_round_molotov "1"
+ze_weapons_round_molotov "3"
 
 // 说  明: 每局最多可购买的冰冻数量 (个)
 // 最小值: -1
 // 最大值: 10
-ze_weapons_round_decoy "-1"
+ze_weapons_round_decoy "2"
 
 // 说  明: 每局最多可购买的屏障数量 (个)
 // 最小值: -1
 // 最大值: 10
-ze_weapons_round_flash "2"
+ze_weapons_round_flash "1"
 
 // 说  明: 每局最多可购买的磁暴数量 (个)
 // 最小值: -1


### PR DESCRIPTION
新版黑水镇新增了第二第三关,其中两关流程为长征,长度与冰龙类似,玩家道具不足故作此修改.