### PR TITLE
修复酸奶滑翔问题

### DIFF
--- a/ZombiEscape/cfg/sourcemod/map-configs/ze_surf_froyo_lite_v2_4.cfg
+++ b/ZombiEscape/cfg/sourcemod/map-configs/ze_surf_froyo_lite_v2_4.cfg
@@ -433,5 +433,6 @@ sm_farter_distance "350.0"
 /// commands
 ///
 ze_start_health_override "1000"
+sv_airaccelerate "150"
 
 Echo "Executed config for ze_surf_froyo_lite_v2_4."

--- a/ZombiEscape/cfg/sourcemod/map-configs/ze_surf_froyo_v2_2.cfg
+++ b/ZombiEscape/cfg/sourcemod/map-configs/ze_surf_froyo_v2_2.cfg
@@ -433,6 +433,6 @@ sm_farter_distance "350.0"
 /// commands
 ///
 ze_start_health_override "1000"
-
+sv_airaccelerate "150"
 
 Echo "Executed config for ze_surf_froyo_v2_2."


### PR DESCRIPTION
由于sv_airaccelerate参数过低导致无法正常滑翔,故修改此参数.