### PR TITLE
狮子王参数修改

### DIFF
--- a/ZombiEscape/cfg/sourcemod/map-configs/ze_santassination_v3.cfg
+++ b/ZombiEscape/cfg/sourcemod/map-configs/ze_santassination_v3.cfg
@@ -82,12 +82,12 @@ zr_infect_mzombie_respawn "1"
 // 说  明: 尸变倒计时<须与zr_infect_spawntime_min同步> (秒)
 // 最小值: 1
 // 最大值: 90
-zr_infect_spawntime_max "12.0"
+zr_infect_spawntime_max "15.0"
 
 // 说  明: 尸变倒计时<须与zr_infect_spawntime_max同步> (秒)
 // 最小值: 1
 // 最大值: 90
-zr_infect_spawntime_min "12.0"
+zr_infect_spawntime_min "15.0"
 
 // 说  明: 死亡复活延迟 (秒)
 // 最小值: 1
@@ -122,7 +122,7 @@ zr_ztele_max_zombie "0"
 // 说  明: 伤害与金钱转化比例 ($)
 // 最小值: 0.0
 // 最大值: 30.0
-ze_damage_zombie_cash "0.35"
+ze_damage_zombie_cash "0.50"
 
 // 说  明: 伤害云点转化比例 (云点)
 // 最小值: 5000.0
@@ -302,12 +302,12 @@ ze_grenade_nade_cfeffect "2"
 // 说  明: 每局开始时补给的金钱 ($)
 // 最小值: 1
 // 最大值: 8000
-ze_weapons_startmoney "5000"
+ze_weapons_startmoney "6000"
 
 // 说  明: 每局最大可购买的Awp数量 (把)
 // 最小值: 0
 // 最大值: 64
-ze_weapons_awp_counts "5"
+ze_weapons_awp_counts "3"
 
 // 说  明: 每局开始时补给的高爆数量 (个)
 // 最小值: 0
@@ -322,7 +322,7 @@ ze_weapons_spawn_molotov "0"
 // 说  明: 每局开始时补给的冰冻数量 (个)
 // 最小值: 0
 // 最大值: 10
-ze_weapons_spawn_decoy "0"
+ze_weapons_spawn_decoy "2"
 
 // 说  明: 每局开始时补给的血针数量 (支)
 // 最小值: 0
@@ -342,7 +342,7 @@ ze_weapons_round_molotov "2"
 // 说  明: 每局最多可购买的冰冻数量 (个)
 // 最小值: -1
 // 最大值: 10
-ze_weapons_round_decoy "2"
+ze_weapons_round_decoy "3"
 
 // 说  明: 每局最多可购买的屏障数量 (个)
 // 最小值: -1
@@ -357,7 +357,7 @@ ze_weapons_round_smoke "1"
 // 说  明: 每局最多可购买的黑洞数量 (个)
 // 最小值: -1
 // 最大值: 5
-ze_weapons_round_tagrenade "1"
+ze_weapons_round_tagrenade "-1"
 
 // 说  明: 每局最多可购买的血针数量 (支)
 // 最小值: -1


### PR DESCRIPTION
尸变倒计时：     <12s/15s>主要针对ACT3开局只有两秒时间需要玩家进行选路->打木门->回头守点，很容易出现开局掉人的情况。
可购买黑洞：     <1/-1>删除黑洞，例如ACT3迷宫，苏格拉底房僵尸传送等更需要玩家合作而不是靠续黑洞拖时间撑到人后撤
初始冰冻弹 :       <0/2>用于替代黑洞。考虑到地图流程，设置为2而不是1
可购买冰冻弹:    <2/3>删除黑洞后需要冰冻弹对尸群控制，提高购买上限
伤害金钱比例:    <0.35/0.50>僵尸护甲版本下金钱获取比例不足以支撑人类的道具要求，黑洞删除后人类撤退也需要更多的道具
初始金钱:           <5k/6k>上调初始金钱，开局撤退时可以使用更多手雷减速僵尸
AWP数量:           <5/3>恢复3把限制。撤退时更多依靠整体火力和道具，且目前服务器版本AWP的收益有限，并影响个人道具数量