### PR TITLE
调整玩家反馈长征图不平衡参数

### DIFF
--- a/ZombiEscape/cfg/sourcemod/map-configs/ze_egyptian_b5.cfg
+++ b/ZombiEscape/cfg/sourcemod/map-configs/ze_egyptian_b5.cfg
@@ -97,7 +97,7 @@ zr_respawn_delay "5.0"
 // 说  明: 全局击退系数 (%)
 // 最小值: 0.1
 // 最大值: 1.5
-zr_knockback_multi "1.0"
+zr_knockback_multi "1.1"
 
 // 说  明: 空中击退系数 (%)
 // 最小值: 0.1
@@ -122,7 +122,7 @@ zr_ztele_max_zombie "1"
 // 说  明: 伤害与金钱转化比例 ($)
 // 最小值: 0.0
 // 最大值: 30.0
-ze_damage_zombie_cash "0.8"
+ze_damage_zombie_cash "0.7"
 
 // 说  明: 伤害云点转化比例 (云点)
 // 最小值: 5000.0
@@ -142,7 +142,7 @@ ze_credits_pass_round "4"
 // 说  明: 通关获得多少云点<人类>
 // 最小值: 0
 // 最大值: 30
-rank_ze_win_points_humans "12"
+rank_ze_win_points_humans "8"
 
 
 ///
@@ -317,7 +317,7 @@ ze_weapons_spawn_hegrenade "1"
 // 说  明: 每局开始时补给的火瓶数量 (个)
 // 最小值: 0
 // 最大值: 10
-ze_weapons_spawn_molotov "0"
+ze_weapons_spawn_molotov "1"
 
 // 说  明: 每局开始时补给的冰冻数量 (个)
 // 最小值: 0
@@ -332,7 +332,7 @@ ze_weapons_spawn_healshot "0"
 // 说  明: 每局最多可购买的高爆数量 (个)
 // 最小值: -1
 // 最大值: 15
-ze_weapons_round_hegrenade "4"
+ze_weapons_round_hegrenade "6"
 
 // 说  明: 每局最多可购买的火瓶数量 (个)
 // 最小值: -1


### PR DESCRIPTION
击退+0.1
打钱比例-0.1
通关云点-4
初始火+1
购买高爆+2