### PR TITLE
Santassination参数修改

### DIFF
--- a/ZombiEscape/cfg/sourcemod/map-configs/ze_santassination_v3.cfg
+++ b/ZombiEscape/cfg/sourcemod/map-configs/ze_santassination_v3.cfg
@@ -82,12 +82,12 @@ zr_infect_mzombie_respawn "1"
 // 说  明: 尸变倒计时<须与zr_infect_spawntime_min同步> (秒)
 // 最小值: 1
 // 最大值: 90
-zr_infect_spawntime_max "12.0"
+zr_infect_spawntime_max "15.0"
 
 // 说  明: 尸变倒计时<须与zr_infect_spawntime_max同步> (秒)
 // 最小值: 1
 // 最大值: 90
-zr_infect_spawntime_min "12.0"
+zr_infect_spawntime_min "15.0"
 
 // 说  明: 死亡复活延迟 (秒)
 // 最小值: 1
@@ -122,7 +122,7 @@ zr_ztele_max_zombie "0"
 // 说  明: 伤害与金钱转化比例 ($)
 // 最小值: 0.0
 // 最大值: 30.0
-ze_damage_zombie_cash "0.35"
+ze_damage_zombie_cash "0.50"
 
 // 说  明: 伤害云点转化比例 (云点)
 // 最小值: 5000.0
@@ -322,7 +322,7 @@ ze_weapons_spawn_molotov "0"
 // 说  明: 每局开始时补给的冰冻数量 (个)
 // 最小值: 0
 // 最大值: 10
-ze_weapons_spawn_decoy "0"
+ze_weapons_spawn_decoy "1"
 
 // 说  明: 每局开始时补给的血针数量 (支)
 // 最小值: 0


### PR DESCRIPTION
尸变时间延长。主要针对ACT3开局玩家黑屏-选路-打木板-回头守点只有两秒时间。容易出现开局掉人情况
增加一颗初始冰。目前版本挂discord情况下初始金钱6000，开局时后撤时道所需具不足，手雷并不能起到很好的效果
上调刷钱比例。目前版本即使AWP命中头部一枪金钱约230左右，考虑到手雷改版后断后需要更大量的道具辅助，故建议上调。