### PR TITLE
修改尸变时间和打钱比例&地图名修改

### DIFF
--- a/ZombiEscape/addons/sourcemod/configs/mapdata.kv
+++ b/ZombiEscape/addons/sourcemod/configs/mapdata.kv
@@ -4930,7 +4930,7 @@
 	}
 	"ze_revue_starlight_a5"
 	{
-		"m_Description"		"*普通* 少女歌剧"
+		"m_Description"		"*普通* 少女歌剧:星之舞台"
 		"m_CertainTimes"		"all"
 		"m_Price"		"200"
 		"m_PricePartyBlock"		"3000"
@@ -5042,7 +5042,7 @@
 	}
 	"ze_prototype_r"
 	{
-		"m_Description"		"*普通* 虐杀原形"
+		"m_Description"		"*普通* 龙门山前传:病毒起源"
 		"m_CertainTimes"		"all"
 		"m_Price"		"200"
 		"m_PricePartyBlock"		"3000"

--- a/ZombiEscape/cfg/sourcemod/map-configs/ze_lucy_escape_v1.cfg
+++ b/ZombiEscape/cfg/sourcemod/map-configs/ze_lucy_escape_v1.cfg
@@ -82,12 +82,12 @@ zr_infect_mzombie_respawn "1"
 // 说  明: 尸变倒计时<须与zr_infect_spawntime_min同步> (秒)
 // 最小值: 1
 // 最大值: 90
-zr_infect_spawntime_max "15.0"
+zr_infect_spawntime_max "18.0"
 
 // 说  明: 尸变倒计时<须与zr_infect_spawntime_max同步> (秒)
 // 最小值: 1
 // 最大值: 90
-zr_infect_spawntime_min "15.0"
+zr_infect_spawntime_min "18.0"
 
 // 说  明: 死亡复活延迟 (秒)
 // 最小值: 1
@@ -122,7 +122,7 @@ zr_ztele_max_zombie "3"
 // 说  明: 伤害与金钱转化比例 ($)
 // 最小值: 0.0
 // 最大值: 30.0
-ze_damage_zombie_cash "0.6"
+ze_damage_zombie_cash "0.8"
 
 // 说  明: 伤害云点转化比例 (云点)
 // 最小值: 5000.0


### PR DESCRIPTION
①"ze_revue_starlight_a5"
"ze_prototype_r"
改名因mapper请求
②僵尸比人类早复活 长征图加0.2增强人类