### PR TITLE
逃生部分翻译修改

### DIFF
--- a/ZombiEscape/addons/sourcemod/configs/console_t/ze_outlast_v2_beta4_fix.txt
+++ b/ZombiEscape/addons/sourcemod/configs/console_t/ze_outlast_v2_beta4_fix.txt
@@ -138,22 +138,22 @@
 
     "||| 45 documents found |||"
     {
-        "chi" "**文档:4/5**"
+        "chi" "**文档:4/5已找到**"
     }
 
     "||| 35 documents found |||"
     {
-        "chi" "**文档:3/5**"
+        "chi" "**文档:3/5已找到**"
     }
 
     "||| 15 documents found |||"
     {
-        "chi" "**文档:1/5**"
+        "chi" "**文档:1/5已找到**"
     }
 
     "||| 25 documents found |||"
     {
-        "chi" "**文档:2/5**"
+        "chi" "**文档:2/5已找到**"
     }
 
     "||| Shoot the Boss and finsh The lasers!  |||"
@@ -168,12 +168,12 @@
 
     "||| 55 documents found |||"
     {
-        "chi" "**文档:5/5**"
+        "chi" "**文档:5/5已找到**"
     }
 
     "||| Security door will Close at 20 second  |||"
     {
-        "chi" "**||| 安全控制室门将在20秒后打开 |||**"
+        "chi" "**||| 安全控制室门将在20秒后关闭 |||**"
     }
 
     "||| Camera Taken |||"
@@ -233,7 +233,7 @@
 
     "||| Security door will Close at 10 second  |||"
     {
-        "chi" "**||| 安全控制室门将在10秒后打开 |||**"
+        "chi" "**||| 安全控制室门将在10秒后关闭 |||**"
     }
 
     "||| Fall Back  |||"


### PR DESCRIPTION
主要为第一关安全控制室的两个关门倒计时翻译错误
文件彩蛋部分补全翻译