### PR TITLE
删除恶魔城屏障

### DIFF
--- a/ZombiEscape/cfg/sourcemod/map-configs/ze_castlevania_p1_7.cfg
+++ b/ZombiEscape/cfg/sourcemod/map-configs/ze_castlevania_p1_7.cfg
@@ -347,7 +347,7 @@ ze_weapons_round_decoy "1"
 // 说  明: 每局最多可购买的屏障数量 (个)
 // 最小值: -1
 // 最大值: 10
-ze_weapons_round_flash "2"
+ze_weapons_round_flash "-1"
 
 // 说  明: 每局最多可购买的磁暴数量 (个)
 // 最小值: -1


### PR DESCRIPTION
恶魔城的屏障说起来有用的也就沼泽关最后炸团扔山洞口和最后雪山关爬梯子有用
建议删除的主要原因还是题材不搭的问题。加上js也有部分神器有操作空间。
建议和老滚白城一样把屏障删了