### PR TITLE
禁用该图大狙

### DIFF
--- a/ZombiEscape/cfg/sourcemod/map-configs/ze_honkai_impact_3rd_cyberpunk_cityv26_5.cfg
+++ b/ZombiEscape/cfg/sourcemod/map-configs/ze_honkai_impact_3rd_cyberpunk_cityv26_5.cfg
@@ -307,7 +307,7 @@ ze_weapons_startmoney "6000"
 // 说  明: 每局最大可购买的Awp数量 (把)
 // 最小值: 0
 // 最大值: 64
-ze_weapons_awp_counts "2"
+ze_weapons_awp_counts "0"
 
 // 说  明: 每局开始时补给的高爆数量 (个)
 // 最小值: 0


### PR DESCRIPTION
因为该图使用大狙容易导致僵尸大飞超车甚至提前触发导致人类团灭,所以该图应该禁用大狙