### PR TITLE
塞尔达冰雪神殿参数平衡

### DIFF
--- a/ZombiEscape/cfg/sourcemod/map-configs/ze_ice_cavern_va4.cfg
+++ b/ZombiEscape/cfg/sourcemod/map-configs/ze_ice_cavern_va4.cfg
@@ -142,7 +142,7 @@ ze_credits_pass_round "4"
 // 说  明: 通关获得多少云点<人类>
 // 最小值: 0
 // 最大值: 30
-rank_ze_win_points_humans "25"
+rank_ze_win_points_humans "8"
 
 
 ///


### PR DESCRIPTION
地图流程8分钟 该图人类冰墙神器有实体 能实现超车提前触发 导致僵尸不吃传送 人类一直到最终守点触发 才会触发僵尸传送 轻松“跑图”通关