### PR TITLE
调整修复精灵塔参数

### DIFF
--- a/ZombiEscape/cfg/sourcemod/map-configs/ze_rizomata_va2.cfg
+++ b/ZombiEscape/cfg/sourcemod/map-configs/ze_rizomata_va2.cfg
@@ -142,7 +142,7 @@ ze_credits_pass_round "4"
 // 说  明: 通关获得多少云点<人类>
 // 最小值: 0
 // 最大值: 30
-rank_ze_win_points_humans "12"
+rank_ze_win_points_humans "10"
 
 
 ///

--- a/ZombiEscape/cfg/sourcemod/map-entwatch/ze_rizomata_va2.cfg
+++ b/ZombiEscape/cfg/sourcemod/map-entwatch/ze_rizomata_va2.cfg
@@ -110,7 +110,7 @@
     }
     "6"
     {
-        "name"          "加速"
+        "name"          "加速带"
         "shortname"     "加速"
         "buttonclass"   "func_button"
         "filtername"    "null"


### PR DESCRIPTION
服务器中读取不到精灵塔的cfg地图配置和entwatch参数，特稍作修改，尝试修复读取参数。