### PR TITLE
修复核电站在推送全服配置时的错误翻译

### DIFF
--- a/ZombiEscape/addons/sourcemod/configs/console_t/ze_Stalker_Ultimate_v2_3_gg.txt
+++ b/ZombiEscape/addons/sourcemod/configs/console_t/ze_Stalker_Ultimate_v2_3_gg.txt
@@ -4,21 +4,21 @@
 	{
 		"chi"		"**这是根据游戏(潜行者)制作的地图 **"
 	}
-	"**The map isnt eazy. It needs good ZE skills and good teamplay**"
+	"**The map isn't eazy. It needs good ZE skills and good teamplay**"
 	{
 		"chi"		"**这不是简单的地图,它需要很好的技术配合和良好的团队 **"
 	}
-	"Map by gleb_erilov(Headshooter.SC) Special thanks to LonllY POMKA Said Z-O-M-B-I-E"
+	"Map by gleb_erilov(Headshooter.SC) Special thanks to HaRyDe POMKA Said Z-O-M-B-I-E"
 	{
-		"chi"		"**地图制作:gleb_erilov(Headshooter.SC)地图翻译:Ruby  特别感谢:LonllY POMKA Said Z-O-M-B-I-E的各位 **"
+		"chi"		"**地图制作:gleb_erilov(Headshooter.SC)地图翻译:Ruby  特别感谢:HaRyDe POMKA Said Z-O-M-B-I-E的各位 **"
 	}
 	"Type in console mat_colorcorrection 1 for dynamic effects!!"
 	{
-		"chi"		"**关闭和开启动态效果在控制台输入mat_colorcorrection 1 **"
+		"chi"		"**祝大家好运**"
 	}
 	"A player picked up meatchunk"
 	{
-		"chi"		"**一名玩家拿起神器诱引 **"
+		"chi"		"**一名玩家拿起神器<重力> **"
 	}
 	"Zombie shield is activated. You have 15 seconds."
 	{
@@ -30,7 +30,7 @@
 	}
 	"A player picked up fireball"
 	{
-		"chi"		"**一名玩家拿起神器火焰 **"
+		"chi"		"**一名玩家拿起神器<火焰> **"
 	}
 	"A player picked up a piece of flesh"
 	{


### PR DESCRIPTION
8F最后那份翻译是对的,但是推送全服的时候,老翻译又覆盖上去了,有些地方对不上,因此作出修改