### PR TITLE
平衡精灵塔参数

### DIFF
--- a/ZombiEscape/cfg/sourcemod/map-configs/ze_rizomata_va2.cfg
+++ b/ZombiEscape/cfg/sourcemod/map-configs/ze_rizomata_va2.cfg
@@ -72,7 +72,7 @@ ze_infection_sort_by_keephuman_desc "1"
 // 说  明: 尸变比 (人)
 // 最小值: 1
 // 最大值: 32
-zr_infect_mzombie_ratio "5"
+zr_infect_mzombie_ratio "6"
 
 // 说  明: 尸变时传送回出生点 (开关)
 // 最小值: 0
@@ -122,7 +122,7 @@ zr_ztele_max_zombie "1"
 // 说  明: 伤害与金钱转化比例 ($)
 // 最小值: 0.0
 // 最大值: 30.0
-ze_damage_zombie_cash "0.8"
+ze_damage_zombie_cash "1.0"
 
 // 说  明: 伤害云点转化比例 (云点)
 // 最小值: 5000.0
@@ -417,7 +417,7 @@ sm_boomer_distance "300.0"
 // 说  明: 勾搭范围 (Unit)
 // 最小值: 1.0
 // 最大值: 9999.9
-sm_smoker_distance "150.0"
+sm_smoker_distance "50.0"
 
 // 说  明: 跳刀伤害 (Unit)
 // 最小值: 1.0


### PR DESCRIPTION
因zm群体加速过于强势，地图已经许久没过最后一关了所以加强一下人类
①降低尸变比。该地图比较吃火力和神器手（守点开阔且后期八个神器）
②提高一点刷钱比例。zm加速基本上只能靠道具断住
③削弱钩子参数。地图神器需贴脸释放，现在经常有钩子钩住神器手的现象..(此前精灵塔钩子参数为10)