### PR TITLE
部分地图开启神器透明

### DIFF
--- a/ZombiEscape/cfg/sourcemod/map-configs/ze_ShroomForest2_p6.cfg
+++ b/ZombiEscape/cfg/sourcemod/map-configs/ze_ShroomForest2_p6.cfg
@@ -192,7 +192,7 @@ ze_buttons_glow_enabled "1"
 // 说  明: 持有神器的玩家会被透明化, 并且在僵尸视野中高亮并透视 (开关)
 // 最小值: 0
 // 最大值: 1
-ze_extended_hide_entwatch_player "0"
+ze_extended_hide_entwatch_player "1"
 
 
 ///

--- a/ZombiEscape/cfg/sourcemod/map-configs/ze_diddle_v3.cfg
+++ b/ZombiEscape/cfg/sourcemod/map-configs/ze_diddle_v3.cfg
@@ -192,7 +192,7 @@ ze_buttons_glow_enabled "0"
 // 说  明: 持有神器的玩家会被透明化, 并且在僵尸视野中高亮并透视 (开关)
 // 最小值: 0
 // 最大值: 1
-ze_extended_hide_entwatch_player "0"
+ze_extended_hide_entwatch_player "1"
 
 
 ///

--- a/ZombiEscape/cfg/sourcemod/map-configs/ze_lotr_minas_tirith_p5.cfg
+++ b/ZombiEscape/cfg/sourcemod/map-configs/ze_lotr_minas_tirith_p5.cfg
@@ -192,7 +192,7 @@ ze_buttons_glow_enabled "1"
 // 说  明: 持有神器的玩家会被透明化, 并且在僵尸视野中高亮并透视 (开关)
 // 最小值: 0
 // 最大值: 1
-ze_extended_hide_entwatch_player "0"
+ze_extended_hide_entwatch_player "1"
 
 
 ///

--- a/ZombiEscape/cfg/sourcemod/map-configs/ze_santassination_v3.cfg
+++ b/ZombiEscape/cfg/sourcemod/map-configs/ze_santassination_v3.cfg
@@ -192,7 +192,7 @@ ze_buttons_glow_enabled "0"
 // 说  明: 持有神器的玩家会被透明化, 并且在僵尸视野中高亮并透视 (开关)
 // 最小值: 0
 // 最大值: 1
-ze_extended_hide_entwatch_player "0"
+ze_extended_hide_entwatch_player "1"
 
 
 ///


### PR DESCRIPTION
蘑菇2：排除终关蘑菇刀神器yek
米纳斯：排除大量神器/障碍物严重干扰视野导致的假摔等。对玩家对抗的影响在实装后视情况决定是否回滚
地豆：排除断口神器持有玩家造成的yek以及消除拆迁队打法下大量神器对视野的干扰
狮子王：排除部分狭窄地形下大量神器对视野造成的干扰，以及持有大量加速情况下对视野的影响