### PR TITLE
修正单机者终极手枪filtername

### DIFF
--- a/ZombiEscape/cfg/sourcemod/map-entwatch/ze_offliner_v2_csgo1.cfg
+++ b/ZombiEscape/cfg/sourcemod/map-entwatch/ze_offliner_v2_csgo1.cfg
@@ -5,7 +5,7 @@
         "name"              "冲击波"
         "shortname"         "终极"
         "buttonclass"       "func_button"
-        "filtername"        "shockwave_item_filter"
+        "filtername"        "player_shockwave_item"
         "hasfiltername"     "true"
         "autotransfer"      "true"
         "hud"               "true"


### PR DESCRIPTION
因为一开始我pr的filtername写错了,导致神器改不出来,现已修改为正确选项