### PR TITLE
更新一夫当关参数

### DIFF
--- a/ZombiEscape/cfg/sourcemod/map-configs/ze_last_man_standing_csgo3.cfg
+++ b/ZombiEscape/cfg/sourcemod/map-configs/ze_last_man_standing_csgo3.cfg
@@ -92,7 +92,7 @@ zr_respawn_delay "5.0"
 // 说  明: 全局击退系数 (%)
 // 最小值: 0.1
 // 最大值: 1.5
-zr_knockback_multi "0.7"
+zr_knockback_multi "1.0"
 
 // 说  明: 空中击退系数 (%)
 // 最小值: 0.1
@@ -117,7 +117,7 @@ zr_ztele_max_zombie "3"
 // 说  明: 伤害与金钱转化比例 ($)
 // 最小值: 0.0
 // 最大值: 30.0
-ze_damage_zombie_cash "1.0"
+ze_damage_zombie_cash "0.8"
 
 // 说  明: 伤害云点转化比例 (云点)
 // 最小值: 5000.0


### PR DESCRIPTION
据观察,EX1和EX2由于击退问题守不住僵尸,目前增加到1.0地面击退,并减少至0.8的打钱比