### PR TITLE
Santa倒计时小修改

### DIFF
--- a/ZombiEscape/addons/sourcemod/configs/console_t/ze_santassination_v3.txt
+++ b/ZombiEscape/addons/sourcemod/configs/console_t/ze_santassination_v3.txt
@@ -661,7 +661,6 @@
 	"***OUTER WALL ENTRANCE IS OPENING IN 30 SECONDS***"
 	{
 		"chi"		"**外墙入口30秒后打开**"
-		"countdown" "60"
 	}
 	"***OUTER WALL ENTRANCE IS OPENING IN 5 SECONDS***"
 	{
@@ -671,6 +670,7 @@
 	"***OUTER WALL ENTRANCE IS OPENING***"
 	{
 		"chi"		"**外墙入口开了**"
+		"countdown" "30"
 	}
 	"***UPPER GATE IS OPENING IN 30 SECONDS***"
 	{
@@ -1101,6 +1101,7 @@
 	"***THE TRUE ELEVATOR IS LEAVING***"
 	{
 		"chi"		"**电梯离开**"
+		"countdown" "38"
 	}
 	"***SOCRATES WISHES SILENTLY***"
 	{
@@ -1125,7 +1126,7 @@
 	"***SOCRATES CARES FOR NO MAN***"
 	{
 		"chi"		"**灼眼尊者不关心人**"
-		"countdown" "50"
+		"countdown" "60"
 	}
 	"***SOCRATES IS***"
 	{


### PR DESCRIPTION
修改独立倒计时时长
1.修改外墙倒计时（被文本倒计时覆盖无法正常显示）
2.里世界倒计时延长到假桥断，增加电梯后传送倒计时