### PR TITLE
提高地豆云点限制

### DIFF
--- a/ZombiEscape/cfg/sourcemod/map-configs/ze_diddle_v3.cfg
+++ b/ZombiEscape/cfg/sourcemod/map-configs/ze_diddle_v3.cfg
@@ -137,7 +137,7 @@ ze_bosshp_vscript_creation "0"
 // 说  明: 拾取神器所需的最低云点 (云点)
 // 最小值: 1
 // 最大值: 10000
-ze_newbee_protection_point "500"
+ze_newbee_protection_point "1500"
 
 // 说  明: XXX: DO NOT CHANGE THIS!!!
 // 最小值: 0


### PR DESCRIPTION
由于近期地豆多次出现“萌新”无视指挥安排配置乱买神器。
导致光速下一把或缺失其他重要神器
故提高地豆云点限制500->1500