### PR TITLE
kv调整和地图调整

### DIFF
--- a/ZombiEscape/addons/sourcemod/configs/console_t/ze_pokemon_adventure_v1_1.txt
+++ b/ZombiEscape/addons/sourcemod/configs/console_t/ze_pokemon_adventure_v1_1.txt
@@ -332,7 +332,7 @@
 
     "** Computer is having a malfunction. Attention keep distance!**"
     {
-        "chi" "**计算机冒烟ind...情况良好... **"
+        "chi" "**计算机冒烟ing...情况良好... **"
     }
 
 }

--- a/ZombiEscape/addons/sourcemod/configs/console_t/ze_yurilnier_beta007_hdr.txt
+++ b/ZombiEscape/addons/sourcemod/configs/console_t/ze_yurilnier_beta007_hdr.txt
@@ -112,12 +112,12 @@
 
     "** PHASE : FRIGUS **"
     {
-        "chi" "** **"
+        "chi" "**第一章:荒芜雪径 **"
     }
 
     "** PHASE : VITAE **"
     {
-        "chi" "** **"
+        "chi" "**第二章:雪域孤城 **"
     }
 
     "** FRIGUS COMPLETED **"

--- a/ZombiEscape/addons/sourcemod/configs/mapdata.kv
+++ b/ZombiEscape/addons/sourcemod/configs/mapdata.kv
@@ -6057,7 +6057,7 @@
 		"m_MaxCooldown"		"150"
 		"m_NominateOnly"		"1"
 		"m_VipOnly"		"0"
-		"m_AdminOnly"		"1"
+		"m_AdminOnly"		"0"
 		"m_RefundRatio"		"0.5"
 	}
 	"ze_traak_b2"
@@ -6072,7 +6072,7 @@
 		"m_MaxCooldown"		"110"
 		"m_NominateOnly"		"0"
 		"m_VipOnly"		"0"
-		"m_AdminOnly"		"1"
+		"m_AdminOnly"		"0"
 		"m_RefundRatio"		"0.3"
 	}
 	"ze_yurilnier_beta007_hdr"
@@ -6087,7 +6087,7 @@
 		"m_MaxCooldown"		"130"
 		"m_NominateOnly"		"1"
 		"m_VipOnly"		"0"
-		"m_AdminOnly"		"1"
+		"m_AdminOnly"		"0"
 		"m_RefundRatio"		"0.5"
 	}
 }

--- a/ZombiEscape/cfg/sourcemod/map-configs/ze_scp_containment_breach_v1_b02_cm4.cfg
+++ b/ZombiEscape/cfg/sourcemod/map-configs/ze_scp_containment_breach_v1_b02_cm4.cfg
@@ -17,12 +17,12 @@
 // 说  明: 地图时间 (分钟)
 // 最小值: 1
 // 最大值: 60
-mp_timelimit "45"
+mp_timelimit "25"
 
 // 说  明: 回合时间 (分钟)
 // 最小值: 1
 // 最大值: 60
-mp_roundtime "30.0"
+mp_roundtime "20.0"
 
 
 ///
@@ -62,7 +62,7 @@ ze_infection_sort_by_keephuman_desc "1"
 // 说  明: 尸变比 (人)
 // 最小值: 1
 // 最大值: 32
-zr_infect_mzombie_ratio "7"
+zr_infect_mzombie_ratio "6"
 
 // 说  明: 尸变时传送回出生点 (开关)
 // 最小值: 0
@@ -84,6 +84,11 @@ zr_infect_spawntime_min "13.0"
 // 最大值: 1.5
 zr_knockback_multi "1.0"
 
+// 说  明: 空中击退系数 (%)
+// 最小值: 0.1
+// 最大值: 1.5
+zr_classes_csgo_knockback_airmultiplier "0.35"
+
 
 ///
 /// Rank
@@ -97,12 +102,12 @@ ze_damage_zombie_cash "0.6"
 // 说  明: 伤害云点转化比例 (云点)
 // 最小值: 5000.0
 // 最大值: 999999.0
-ze_damage_rank_points "18000"
+ze_damage_rank_points "20000"
 
 // 说  明: 伤害积分转化比例 (积分)
 // 最小值: 5000.0
 // 最大值: 999999.0
-ze_damage_shop_credit "24000"
+ze_damage_shop_credit "26000"
 
 // 说  明: 通关所获得的积分 (积分)
 // 最小值: 0
@@ -112,7 +117,7 @@ ze_credits_pass_round "3"
 // 说  明: 通关获得多少云点<人类>
 // 最小值: 0
 // 最大值: 30
-rank_ze_win_points_humans "7"
+rank_ze_win_points_humans "6"
 
 
 ///
@@ -222,7 +227,7 @@ ze_weapons_spawn_hegrenade "1"
 // 说  明: 每局开始时补给的火瓶数量 (个)
 // 最小值: 0
 // 最大值: 10
-ze_weapons_spawn_molotov "1"
+ze_weapons_spawn_molotov "0"
 
 // 说  明: 每局开始时补给的冰冻数量 (个)
 // 最小值: 0


### PR DESCRIPTION
①上一批新图经过多次实战测试可以开放预订(测试负责人:龙鸣)
②修复ze_pokemon_adventure_v1_1和ze_yurilnier_beta007_hdr的console_t文件错误
③调整scp的不合理zconfig 因为过于刷分僵尸无体验