### PR TITLE
老乐高开启手电筒

### DIFF
--- a/ZombiEscape/cfg/sourcemod/map-configs/ze_fapescape_p5.cfg
+++ b/ZombiEscape/cfg/sourcemod/map-configs/ze_fapescape_p5.cfg
@@ -167,7 +167,7 @@ k_nv_enabled "0"
 // 说  明: 手电筒控制 (开关)
 // 最小值: 0
 // 最大值: 1
-k_fl_enabled "0"
+k_fl_enabled "1"
 
 
 ///


### PR DESCRIPTION
主要为Normal2,Normal3,EX2,EX3的部分阴暗场景下容易被yek导致掉人
故开放手电筒