### PR TITLE
kv调整和地图调整

### DIFF
--- a/ZombiEscape/addons/sourcemod/configs/bosshp/ze_destruction_of_exorath_v4_lite.cfg
+++ b/ZombiEscape/addons/sourcemod/configs/bosshp/ze_destruction_of_exorath_v4_lite.cfg
@@ -9,20 +9,16 @@
             "displayname"   "低阶变异海苔"
             "hitbox"        "boss_extreme_hitpoint"
 		}
-	}
-	"counter"
-	{
-		"0"
+
+		"1"
 		{
 			"iterator"		"healbar_counter_god"
             "counter"		"healbar_count_total2"
             "displayname"   "高阶变异海苔"
             "hitbox"        "boss_godmode_hitpoint"
 		}
-	}
-	"counter"
-	{
-		"0"
+		
+		"2"
 		{
 			"iterator"		"healbar_counter_impossible"
             "counter"		"healbar_count_total2"

--- a/ZombiEscape/addons/sourcemod/configs/bosshp/ze_destruction_of_exorath_v4_lite.cfg
+++ b/ZombiEscape/addons/sourcemod/configs/bosshp/ze_destruction_of_exorath_v4_lite.cfg
@@ -6,6 +6,7 @@
 		{
 			"iterator"		"healbar_counter_extreme"
             "counter"		"healbar_count_total2"
+			"countermode"   "1"
             "displayname"   "低阶变异海苔"
             "hitbox"        "boss_extreme_hitpoint"
 		}
@@ -13,7 +14,8 @@
 		"1"
 		{
 			"iterator"		"healbar_counter_god"
-            "counter"		"healbar_count_total2"
+            "counter"		"healbar_count_total3"
+			"countermode"   "1"
             "displayname"   "高阶变异海苔"
             "hitbox"        "boss_godmode_hitpoint"
 		}
@@ -21,7 +23,8 @@
 		"2"
 		{
 			"iterator"		"healbar_counter_impossible"
-            "counter"		"healbar_count_total2"
+            "counter"		"healbar_count_total5"
+			"countermode"   "1"
             "displayname"   "无敌变异海苔"
             "hitbox"        "boss_impossible_hitpoint"
 		}

--- a/ZombiEscape/addons/sourcemod/configs/console_t/ze_ocean_base_escape_p2.txt
+++ b/ZombiEscape/addons/sourcemod/configs/console_t/ze_ocean_base_escape_p2.txt
@@ -89,6 +89,7 @@
     "***The Ocean Base is starting to explode!***"
     {
         "chi" "**检测到生化污染!深海基地自毁启动! **"
+		"command"       "ze_weapons_round_molotov -1"
     }
 
     "***Find a place to hide and hold here for 45secs until a path is clear!!***"
@@ -160,13 +161,13 @@
     "***...Thank you...<<Insert Name Here>>...**"
     {
         "chi" "**蟹蟹你 勇士 **"
-		"command"       "sm_smoker_enabled 1"
-		"command"       "ze_weapons_round_molotov -1"
     }
 
     "***Thank You for Playing!!***"
     {
         "chi" "**同时也感谢你们的游玩 汉化:龙鸣 **"
+		"command"       "ze_weapons_round_molotov -1"
+		"command"       "sm_smoker_enabled 1"
     }
 
     "***Use the pipes along the wall to get across the pit of fire!***"

--- a/ZombiEscape/addons/sourcemod/configs/mapdata.kv
+++ b/ZombiEscape/addons/sourcemod/configs/mapdata.kv
@@ -6102,7 +6102,7 @@
 		"m_MaxCooldown"		"110"
 		"m_NominateOnly"		"0"
 		"m_VipOnly"		"0"
-		"m_AdminOnly"		"1"
+		"m_AdminOnly"		"0"
 		"m_RefundRatio"		"0.3"
 	}
 	"ze_eschaton_a3_1"
@@ -6132,7 +6132,7 @@
 		"m_MaxCooldown"		"130"
 		"m_NominateOnly"		"1"
 		"m_VipOnly"		"0"
-		"m_AdminOnly"		"1"
+		"m_AdminOnly"		"0"
 		"m_RefundRatio"		"0.5"
 	}
 	"ze_parkour_k"
@@ -6147,7 +6147,7 @@
 		"m_MaxCooldown"		"110"
 		"m_NominateOnly"		"0"
 		"m_VipOnly"		"0"
-		"m_AdminOnly"		"1"
+		"m_AdminOnly"		"0
 		"m_RefundRatio"		"0.3"
 	}
 	"ze_flower_a1_2"

--- a/ZombiEscape/cfg/sourcemod/map-configs/ze_blood_castle_b7.cfg
+++ b/ZombiEscape/cfg/sourcemod/map-configs/ze_blood_castle_b7.cfg
@@ -82,7 +82,7 @@ zr_infect_spawntime_min "15.0"
 // 说  明: 全局击退系数 (%)
 // 最小值: 0.1
 // 最大值: 1.5
-zr_knockback_multi "0.65"
+zr_knockback_multi "0.95"
 
 // 说  明: 空中击退系数 (%)
 // 最小值: 0.1
@@ -247,7 +247,7 @@ ze_weapons_round_hegrenade "3"
 // 说  明: 每局最多可购买的火瓶数量 (个)
 // 最小值: -1
 // 最大值: 10
-ze_weapons_round_molotov "-1"
+ze_weapons_round_molotov "1"
 
 // 说  明: 每局最多可购买的冰冻数量 (个)
 // 最小值: -1


### PR DESCRIPTION
①上一批新图经过多次实战测试可以开放预订(测试负责人:龙鸣)
②修复ze_destruction_of_exorath_v4_lite的bosshp和ze_ocean_base_escape_p2的动态参数
③调整ze_blood_castle_b7的zconfig 实战测试后根据守则加强弱势方