### PR TITLE
无名地图参数更改

### DIFF
--- a/ZombiEscape/cfg/sourcemod/map-configs/ze_no_name_v1_6.cfg
+++ b/ZombiEscape/cfg/sourcemod/map-configs/ze_no_name_v1_6.cfg
@@ -102,7 +102,7 @@ ze_damage_rank_points "18000"
 // 说  明: 伤害积分转化比例 (积分)
 // 最小值: 5000.0
 // 最大值: 999999.0
-ze_damage_shop_credit "2400"
+ze_damage_shop_credit "24000"
 
 // 说  明: 通关所获得的积分 (积分)
 // 最小值: 0


### PR DESCRIPTION
一张刷分图，2400伤害转换1积分过于离谱，故更改为24000