### PR TITLE
下调精灵塔AWP可购买数量

### DIFF
--- a/ZombiEscape/cfg/sourcemod/map-configs/ze_rizomata_va2.cfg
+++ b/ZombiEscape/cfg/sourcemod/map-configs/ze_rizomata_va2.cfg
@@ -212,7 +212,7 @@ ze_grenade_nade_cfeffect "1"
 // 说  明: 每局最大可购买的Awp数量 (把)
 // 最小值: 0
 // 最大值: 64
-ze_weapons_awp_counts "3"
+ze_weapons_awp_counts "1"
 
 // 说  明: 每局开始时补给的高爆数量 (个)
 // 最小值: 0


### PR DESCRIPTION
AWP的超高击退对zm的压制力远超于人类神器及道具，故申请下调其可购买数量。