### PR TITLE
更改次级僵尸血量

### DIFF
--- a/ZombiEscape/cfg/sourcemod/map-configs/ze_lotr_minas_tirith_p5.cfg
+++ b/ZombiEscape/cfg/sourcemod/map-configs/ze_lotr_minas_tirith_p5.cfg
@@ -299,10 +299,10 @@ sm_farter_distance "350.0"
 ///    Commands    ///
 //////////////////////
 
-zr_class_modify "普通僵尸" "health" "4000"
-zr_class_modify "加速僵尸" "health" "4000"
-zr_class_modify "闪灵僵尸" "health" "4000"
-zr_class_modify "唾沫僵尸" "health" "4000"
+zr_class_modify "普通僵尸" "health" "6000"
+zr_class_modify "加速僵尸" "health" "6000"
+zr_class_modify "闪灵僵尸" "health" "6000"
+zr_class_modify "唾沫僵尸" "health" "6000"
 zr_class_modify "母体僵尸" "health" "8000"
 zr_class_modify "普通僵尸" "health_regen_amount" "100"
 zr_class_modify "加速僵尸" "health_regen_amount" "100"


### PR DESCRIPTION
根据地雷对僵尸造成大额伤害，调整次级僵尸血量上限，避免大反馈地雷清场