### PR TITLE
修改地图参数:ze_sky_athletic_adv_v9_12修改为开放预订

### DIFF
--- a/ZombiEscape/addons/sourcemod/configs/mapdata.kv
+++ b/ZombiEscape/addons/sourcemod/configs/mapdata.kv
@@ -3460,9 +3460,9 @@
         "m_MinPlayers"        "0"
         "m_MaxPlayers"        "0"
         "m_MaxCooldown"       "120"
-        "m_NominateOnly"      "1"
+        "m_NominateOnly"      "0"
         "m_VipOnly"           "0"
-        "m_AdminOnly"         "1"
+        "m_AdminOnly"         "0"
         "m_RefundRatio"       "0.4"
     }
     "ze_sky_fantasy_v1_4"


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_sky_athletic_adv_v9_12
## 为什么要增加/修改这个东西
修改为开放所有人预订地图
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
