### PR TITLE
修改地图数据: ze_hydroponic_garden_v1_1

### DIFF
--- a/ZombiEscape/cfg/sourcemod/map-configs/ze_hydroponic_garden_v1_1.cfg
+++ b/ZombiEscape/cfg/sourcemod/map-configs/ze_hydroponic_garden_v1_1.cfg
@@ -93,7 +93,7 @@ zr_knockback_multi "1.3"
 // 说  明: 伤害与金钱转化比例 ($)
 // 最小值: 0.1
 // 最大值: 3.0
-ze_damage_zombie_cash "0.6"
+ze_damage_zombie_cash "0.8"
 
 // 说  明: 伤害云点转化比例 (云点)
 // 最小值: 5000.0
@@ -203,7 +203,7 @@ ze_savelevel_multis "0"
 // 说  明: 高爆模式, 0为禁用, 1 = 燃烧, 2 = 减速, 3 = 击退 (开关)
 // 最小值: 0
 // 最大值: 3
-ze_grenade_nade_cfeffect "1"
+ze_grenade_nade_cfeffect "3"
 
 
 ///


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_hydroponic_garden_v1_1
## 为什么要增加/修改这个东西
该地图流程较短且守点困难，且在第四关的低重力下拾取神器的闪灵僵尸可以大飞操作，实战及其困难，所以修改打钱比和高爆雷为击退雷。
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
