### PR TITLE
修改地图参数: ze_check_b1_1

### DIFF
--- a/ZombiEscape/cfg/sourcemod/map-configs/ze_check_b1_1.cfg
+++ b/ZombiEscape/cfg/sourcemod/map-configs/ze_check_b1_1.cfg
@@ -268,7 +268,7 @@ ze_weapons_round_healshot "2"
 // 说  明: 闪灵冲刺推力 (Unit)
 // 最小值: 150.0
 // 最大值: 500.0
-sm_hunter_leappower "300.0"
+sm_hunter_leappower "175.0"
 
 // 说  明: 加速暴发冲力 (%)
 // 最小值: 1.1


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_check_b1_1
## 为什么要增加/修改这个东西
闪灵参数过高，导致当前地图人类难度过大，不符地图普通分类，以致无人问津
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
