### PR TITLE
修改地图参数: ze_lotr_mirkwood_v2_5

### DIFF
--- a/ZombiEscape/cfg/sourcemod/map-configs/ze_lotr_mirkwood_v2_5.cfg
+++ b/ZombiEscape/cfg/sourcemod/map-configs/ze_lotr_mirkwood_v2_5.cfg
@@ -83,7 +83,7 @@ zr_infect_spawntime_min "15.0"
 // 说  明: 全局击退系数 (%)
 // 最小值: 0.1
 // 最大值: 1.5
-zr_knockback_multi "1.0"
+zr_knockback_multi "1.3"
 
 
 ///
@@ -113,7 +113,7 @@ ze_credits_pass_round "4"
 // 说  明: 通关获得多少云点<人类>
 // 最小值: 1
 // 最大值: 30
-rank_ze_win_points_humans "6"
+rank_ze_win_points_humans "10"
 
 
 ///
@@ -223,7 +223,7 @@ ze_weapons_spawn_hegrenade "1"
 // 说  明: 每局开始时补给的火瓶数量 (个)
 // 最小值: 0
 // 最大值: 1
-ze_weapons_spawn_molotov "0"
+ze_weapons_spawn_molotov "1"
 
 // 说  明: 每局开始时补给的冰冻数量 (个)
 // 最小值: 0
@@ -233,12 +233,12 @@ ze_weapons_spawn_decoy "1"
 // 说  明: 每局最多可购买的高爆数量 (个)
 // 最小值: -1
 // 最大值: 15
-ze_weapons_round_hegrenade "4"
+ze_weapons_round_hegrenade "6"
 
 // 说  明: 每局最多可购买的火瓶数量 (个)
 // 最小值: -1
 // 最大值: 10
-ze_weapons_round_molotov "2"
+ze_weapons_round_molotov "4"
 
 // 说  明: 每局最多可购买的冰冻数量 (个)
 // 最小值: -1
@@ -268,7 +268,7 @@ ze_weapons_round_healshot "2"
 // 说  明: 闪灵冲刺推力 (Unit)
 // 最小值: 150.0
 // 最大值: 500.0
-sm_hunter_leappower "300.0"
+sm_hunter_leappower "150.0"
 
 // 说  明: 加速暴发冲力 (%)
 // 最小值: 1.1


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_lotr_mirkwood_v2_5
## 为什么要增加/修改这个东西
社区老地图，地图本身难度过大，闪灵参数过高，以及炸SV等问题导致地图无法通关，增加击退与道具数量以优化体验
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
