### PR TITLE
修改地图参数: ze_realm_v1_1

### DIFF
--- a/ZombiEscape/cfg/sourcemod/map-configs/ze_realm_v1_1.cfg
+++ b/ZombiEscape/cfg/sourcemod/map-configs/ze_realm_v1_1.cfg
@@ -233,12 +233,12 @@ ze_weapons_spawn_decoy "1"
 // 说  明: 每局最多可购买的高爆数量 (个)
 // 最小值: -1
 // 最大值: 15
-ze_weapons_round_hegrenade "7"
+ze_weapons_round_hegrenade "8"
 
 // 说  明: 每局最多可购买的火瓶数量 (个)
 // 最小值: -1
 // 最大值: 10
-ze_weapons_round_molotov "2"
+ze_weapons_round_molotov "4"
 
 // 说  明: 每局最多可购买的冰冻数量 (个)
 // 最小值: -1


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_realm_v1_1
## 为什么要增加/修改这个东西
地图道具数量不足，根据当前游玩体验提升人类道具数量以优化，降低一些人类过图难度压力
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
