### PR TITLE
修改地图参数: ze_egyptian_b5

### DIFF
--- a/ZombiEscape/cfg/sourcemod/map-configs/ze_egyptian_b5.cfg
+++ b/ZombiEscape/cfg/sourcemod/map-configs/ze_egyptian_b5.cfg
@@ -238,7 +238,7 @@ ze_weapons_round_hegrenade "6"
 // 说  明: 每局最多可购买的火瓶数量 (个)
 // 最小值: -1
 // 最大值: 10
-ze_weapons_round_molotov "2"
+ze_weapons_round_molotov "4"
 
 // 说  明: 每局最多可购买的冰冻数量 (个)
 // 最小值: -1
@@ -268,7 +268,7 @@ ze_weapons_round_healshot "2"
 // 说  明: 闪灵冲刺推力 (Unit)
 // 最小值: 150.0
 // 最大值: 500.0
-sm_hunter_leappower "200.0"
+sm_hunter_leappower "150.0"
 
 // 说  明: 加速暴发冲力 (%)
 // 最小值: 1.1


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_egyptian_b5
## 为什么要增加/修改这个东西
地图多大场景守点，流程偏长，闪灵在近一半的地图流程中过强，调整闪灵参数，略微增加人类火瓶道具以符合地图普通分类
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
