### PR TITLE
修改地图数据: ze_aot_trost_v6_2

### DIFF
--- a/ZombiEscape/addons/sourcemod/configs/mapdata.kv
+++ b/ZombiEscape/addons/sourcemod/configs/mapdata.kv
@@ -5674,7 +5674,7 @@
     {
         "m_Description"       "巨人:托洛斯特"
         "m_Difficulty"        "3"
-        "m_CertainTimes"      "all"
+        "m_CertainTimes"      "8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"
         "m_Price"             "200"
         "m_PricePartyBlock"   "5000"
         "m_MinPlayers"        "0"


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_aot_trost_v6_2
## 为什么要增加/修改这个东西
根据玩家反馈屏蔽深夜预订时段
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
