### PR TITLE
修改地图参数: ze_revue_starlight_v3

### DIFF
--- a/ZombiEscape/cfg/sourcemod/map-configs/ze_revue_starlight_v3.cfg
+++ b/ZombiEscape/cfg/sourcemod/map-configs/ze_revue_starlight_v3.cfg
@@ -73,12 +73,12 @@ zr_infect_mzombie_respawn "1"
 // 说  明: 尸变倒计时<须与zr_infect_spawntime_min同步> (秒)
 // 最小值: 1
 // 最大值: 90
-zr_infect_spawntime_max "15.0"
+zr_infect_spawntime_max "11.0"
 
 // 说  明: 尸变倒计时<须与zr_infect_spawntime_max同步> (秒)
 // 最小值: 1
 // 最大值: 90
-zr_infect_spawntime_min "15.0"
+zr_infect_spawntime_min "11.0"
 
 // 说  明: 全局击退系数 (%)
 // 最小值: 0.1


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_revue_starlight_v3
## 为什么要增加/修改这个东西
尸变时间过长，玩家拾取匕首类神器后尸变导致本局神器缺失
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
