### PR TITLE
补充地图关卡: ze_bioshock_v7_1_csgo_a2

### DIFF
--- a/ZombiEscape/addons/sourcemod/configs/mapdata.kv
+++ b/ZombiEscape/addons/sourcemod/configs/mapdata.kv
@@ -3492,7 +3492,7 @@
         "m_MaxCooldown"       "180"
         "m_NominateOnly"      "1"
         "m_VipOnly"           "0"
-        "m_AdminOnly"         "1"
+        "m_AdminOnly"         "0"
         "m_RefundRatio"       "0.5"
     }
     "ze_sorrento_escape_v2"

--- a/ZombiEscape/addons/sourcemod/configs/mapstage.kv
+++ b/ZombiEscape/addons/sourcemod/configs/mapstage.kv
@@ -73,6 +73,11 @@
         "stages"  "5"
         "extreme" "false"
     }
+    "ze_bioshock_v7_1_csgo_a2"
+    {
+        "stages"  "5"
+        "extreme" "false"
+    }
     "ze_bloodstrike_escape_v2"
     {
         "stages"  "3"


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_bioshock_v7_1_csgo_a2
## 为什么要增加/修改这个东西
补充地图关卡
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
