### PR TITLE
修改地图参数:ze_honkai_impact_3rd_cyberpunk_cityv26_5

### DIFF
--- a/ZombiEscape/cfg/sourcemod/map-configs/ze_honkai_impact_3rd_cyberpunk_cityv26_5.cfg
+++ b/ZombiEscape/cfg/sourcemod/map-configs/ze_honkai_impact_3rd_cyberpunk_cityv26_5.cfg
@@ -33,12 +33,12 @@ mp_roundtime "30.0"
 // 说  明: VIP延长投票 (次)
 // 最小值: 0
 // 最大值: 2
-vips_map_extend_times "2"
+vips_map_extend_times "1"
 
 // 说  明: MCR延长投票 (次)
 // 最小值: 0
 // 最大值: 2
-mcr_map_extend_times "2"
+mcr_map_extend_times "1"
 
 
 ///


### PR DESCRIPTION
## 该PR作用的地图是仅英文小写)
ze_honkai_impact_3rd_cyberpunk_cityv26_5
## 为什么要增加/修改这个东西
地图流程过短，且为1关。
初始时间45分钟，过多延长不合理。
削减为1次VIP延长，1次地图延长。
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
