### PR TITLE
修改地图参数: ze_obj_void_b4_t2

### DIFF
--- a/ZombiEscape/cfg/sourcemod/map-configs/ze_obj_void_b4_t2.cfg
+++ b/ZombiEscape/cfg/sourcemod/map-configs/ze_obj_void_b4_t2.cfg
@@ -283,7 +283,7 @@ sm_boomer_distance "300.0"
 // 说  明: 勾搭范围 (Unit)
 // 最小值: 100.0
 // 最大值: 9999.9
-sm_smoker_distance "230.0"
+sm_smoker_distance "150.0"
 
 // 说  明: 跳刀伤害 (Unit)
 // 最小值: 30.0


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_obj_void_b4_t2
## 为什么要增加/修改这个东西
测试参数平衡
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
