### PR TITLE
修改Surf服务器配置: surftimer.cfg

### DIFF
--- a/Surf/cfg/sourcemod/surftimer.cfg
+++ b/Surf/cfg/sourcemod/surftimer.cfg
@@ -272,7 +272,7 @@ ck_noblock "1"
 // Default: "1"
 // Minimum: "0.000000"
 // Maximum: "1.000000"
-ck_noclip "0"
+ck_noclip "1"
 
 // Enables/Disables the one jump limit globally for all zones
 // -
@@ -289,7 +289,7 @@ ck_pause "1"
 // Sets whether the sm_replay command will be VIP only Disable/Enable
 // -
 // Default: "1"
-ck_play_replay_vip_only "1"
+ck_play_replay_vip_only "0"
 
 // Player arm skin
 // -


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)

## 为什么要增加/修改这个东西
已重新修改上传，开放sm_nc 和sm_replay，使玩家可以在服务器使用/nc穿墙功能以及/replay电脑路线选择播放功能
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
