### PR TITLE
修改地图关卡: ze_skyscraper_city_v5

### DIFF
--- a/ZombiEscape/addons/sourcemod/configs/mapstage.kv
+++ b/ZombiEscape/addons/sourcemod/configs/mapstage.kv
@@ -807,7 +807,7 @@
         "stages"  "3"
         "extreme" "false"
     }
-    "ze_skyscraper_city_v5"
+    "ze_mirrors_edge_reborn_v4_2_p3_xfix"
     {
         "stages"  "5"
         "extreme" "false"

--- a/ZombiEscape/cfg/sourcemod/map-configs/ze_skyscraper_city_v5.cfg
+++ b/ZombiEscape/cfg/sourcemod/map-configs/ze_skyscraper_city_v5.cfg
@@ -33,7 +33,7 @@ mp_roundtime "15.0"
 // 说  明: VIP延长投票 (次)
 // 最小值: 0
 // 最大值: 2
-vips_map_extend_times "1"
+vips_map_extend_times "0"
 
 // 说  明: MCR延长投票 (次)
 // 最小值: 0


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_skyscraper_city_v5
## 为什么要增加/修改这个东西
地图名字错误导致两张图的关卡互换
降低单关地图总时长，防止过度刷分
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
