### PR TITLE
修改地图参数: ze_mission_escape_v1

### DIFF
--- a/ZombiEscape/cfg/sourcemod/map-configs/ze_mission_escape_v1.cfg
+++ b/ZombiEscape/cfg/sourcemod/map-configs/ze_mission_escape_v1.cfg
@@ -23,7 +23,7 @@ mp_timelimit "25"
 // 说  明: 回合时间 (分钟)
 // 最小值: 1
 // 最大值: 60
-mp_roundtime "15.0"
+mp_roundtime "8.0"
 
 
 ///
@@ -98,12 +98,12 @@ ze_damage_zombie_cash "0.7"
 // 说  明: 伤害云点转化比例 (云点)
 // 最小值: 5000.0
 // 最大值: 99999.0
-ze_damage_rank_points "18000"
+ze_damage_rank_points "40000"
 
 // 说  明: 伤害积分转化比例 (积分)
 // 最小值: 5000.0
 // 最大值: 99999.0
-ze_damage_shop_credit "20000"
+ze_damage_shop_credit "50000"
 
 // 说  明: 通关所获得的积分 (积分)
 // 最小值: 1


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_mission_escape_v1
## 为什么要增加/修改这个东西
该图一回合能刷20w伤害以上且地图难度简单，故降低伤害转化比例
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
