### PR TITLE
修改地图参数: ze_ffvii_mako_reactor_v6_b09k2

### DIFF
--- a/ZombiEscape/cfg/sourcemod/map-configs/ze_ffvii_mako_reactor_v6_b09k2.cfg
+++ b/ZombiEscape/cfg/sourcemod/map-configs/ze_ffvii_mako_reactor_v6_b09k2.cfg
@@ -203,7 +203,7 @@ ze_savelevel_multis "0"
 // 说  明: 高爆模式, 0为禁用, 1 = 燃烧, 2 = 减速, 3 = 击退 (开关)
 // 最小值: 0
 // 最大值: 3
-ze_grenade_nade_cfeffect "1"
+ze_grenade_nade_cfeffect "3"
 
 
 ///
@@ -223,7 +223,7 @@ ze_weapons_spawn_hegrenade "1"
 // 说  明: 每局开始时补给的火瓶数量 (个)
 // 最小值: 0
 // 最大值: 1
-ze_weapons_spawn_molotov "1"
+ze_weapons_spawn_molotov "0"
 
 // 说  明: 每局开始时补给的冰冻数量 (个)
 // 最小值: 0


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_ffvii_mako_reactor_v6_b09k2
## 为什么要增加/修改这个东西
人类胜率不足两位数 僵尸胜率已达三位数 人类个体素质过低导致地图机制严重不平衡 根据守则不应削弱强势方 故增强弱势方 已上
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
