### PR TITLE
修改地图参数: ze_obj_rescape_v1

### DIFF
--- a/ZombiEscape/cfg/sourcemod/map-configs/ze_obj_rescape_v1.cfg
+++ b/ZombiEscape/cfg/sourcemod/map-configs/ze_obj_rescape_v1.cfg
@@ -153,7 +153,7 @@ ze_entwatch_require_client "0"
 // 说  明: 按钮创建高亮透视鸡 (开关)
 // 最小值: 0
 // 最大值: 1
-ze_buttons_glow_enabled "0"
+ze_buttons_glow_enabled "1"
 
 
 ///

--- a/ZombiEscape/cfg/sourcemod/map-configs/ze_obj_rescape_v1.cfg
+++ b/ZombiEscape/cfg/sourcemod/map-configs/ze_obj_rescape_v1.cfg
@@ -83,7 +83,7 @@ zr_infect_spawntime_min "18.0"
 // 说  明: 全局击退系数 (%)
 // 最小值: 0.1
 // 最大值: 1.5
-zr_knockback_multi "1.4"
+zr_knockback_multi "1.5"
 
 
 ///
@@ -93,7 +93,7 @@ zr_knockback_multi "1.4"
 // 说  明: 伤害与金钱转化比例 ($)
 // 最小值: 0.1
 // 最大值: 3.0
-ze_damage_zombie_cash "0.8"
+ze_damage_zombie_cash "1.0"
 
 // 说  明: 伤害云点转化比例 (云点)
 // 最小值: 5000.0
@@ -273,12 +273,12 @@ sm_hunter_leappower "150.0"
 // 说  明: 加速暴发冲力 (%)
 // 最小值: 1.1
 // 最大值: 2.0
-sm_faster_maxspeed "1.5"
+sm_faster_maxspeed "1.3"
 
 // 说  明: 唾液射程 (Unit)
 // 最小值: 100.0
 // 最大值: 999.9
-sm_boomer_distance "200.0"
+sm_boomer_distance "100.0"
 
 // 说  明: 勾搭范围 (Unit)
 // 最小值: 100.0
@@ -293,7 +293,7 @@ sm_blader_damage "30.0"
 // 说  明: 毒烟半径 (Unit)
 // 最小值: 50.0
 // 最大值: 9999.9
-sm_farter_distance "250.0"
+sm_farter_distance "50.0"
 
 
 Echo "Executed config for ze_obj_rescape_v1."


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_obj_rescape_v1
## 为什么要增加/修改这个东西
恢复按钮可视，方便查看是否触发.
根据第二次开荒加强人类 削减僵尸技能范围
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
