### PR TITLE
修改地图参数: ze_aot_trost_v8_2

### DIFF
--- a/ZombiEscape/cfg/sourcemod/map-configs/ze_aot_trost_v8_2.cfg
+++ b/ZombiEscape/cfg/sourcemod/map-configs/ze_aot_trost_v8_2.cfg
@@ -83,7 +83,7 @@ zr_infect_spawntime_min "12.0"
 // 说  明: 全局击退系数 (%)
 // 最小值: 0.1
 // 最大值: 1.5
-zr_knockback_multi "1.0"
+zr_knockback_multi "1.2"
 
 
 ///
@@ -253,7 +253,7 @@ ze_weapons_round_flash "-1"
 // 说  明: 每局最多可购买的黑洞数量 (个)
 // 最小值: -1
 // 最大值: 5
-ze_weapons_round_tagrenade "-1"
+ze_weapons_round_tagrenade "1"
 
 // 说  明: 每局最多可购买的血针数量 (支)
 // 最小值: -1


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_aot_trost_v8_2
## 为什么要增加/修改这个东西
该图过于依赖神器且通关率低，神器出错大概率造成人类团灭，故加强击退增加容错；应作者要求开放黑洞雷购买。
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
