### PR TITLE
修改地图参数: ze_mission_escape_v1

### DIFF
--- a/ZombiEscape/cfg/sourcemod/map-configs/ze_mission_escape_v1.cfg
+++ b/ZombiEscape/cfg/sourcemod/map-configs/ze_mission_escape_v1.cfg
@@ -73,12 +73,12 @@ zr_infect_mzombie_respawn "1"
 // 说  明: 尸变倒计时<须与zr_infect_spawntime_min同步> (秒)
 // 最小值: 1
 // 最大值: 90
-zr_infect_spawntime_max "18.0"
+zr_infect_spawntime_max "12.0"
 
 // 说  明: 尸变倒计时<须与zr_infect_spawntime_max同步> (秒)
 // 最小值: 1
 // 最大值: 90
-zr_infect_spawntime_min "18.0"
+zr_infect_spawntime_min "12.0"
 
 // 说  明: 全局击退系数 (%)
 // 最小值: 0.1
@@ -98,12 +98,12 @@ ze_damage_zombie_cash "0.7"
 // 说  明: 伤害云点转化比例 (云点)
 // 最小值: 5000.0
 // 最大值: 99999.0
-ze_damage_rank_points "40000"
+ze_damage_rank_points "28000"
 
 // 说  明: 伤害积分转化比例 (积分)
 // 最小值: 5000.0
 // 最大值: 99999.0
-ze_damage_shop_credit "50000"
+ze_damage_shop_credit "32000"
 
 // 说  明: 通关所获得的积分 (积分)
 // 最小值: 1


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_mission_escape_v1
## 为什么要增加/修改这个东西

1. 地图出生点秒传且需要防守出生点
2. 地图前期有点难度，开局防守范围极大，往往坚持不到出门就全体被抓
3. 第一个守点后的撤退路线如果有董哥僵尸往往会加速超车团灭人类
4. 地图通关率对比其他咸鱼图通关率其实并不算高
5. 地图通关人数往往只有一半
6. 综合考虑以下通关伤害奖励结算较为合理

## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
