### PR TITLE
修改地图参数: ze_harry_potter_v2_1_csgo

### DIFF
--- a/ZombiEscape/addons/sourcemod/configs/mapdata.kv
+++ b/ZombiEscape/addons/sourcemod/configs/mapdata.kv
@@ -7590,4 +7590,19 @@
         "m_AdminOnly"         "0"
         "m_RefundRatio"       "0.5"
     }
+	"ze_harry_potter_v2_1_csgo"
+    {
+        "m_Description"       "哈利波特传说传记"
+        "m_Difficulty"        "6"
+        "m_CertainTimes"      "all"
+        "m_Price"             "100"
+        "m_PricePartyBlock"   "3000"
+        "m_MinPlayers"        "0"
+        "m_MaxPlayers"        "0"
+        "m_MaxCooldown"       "10"
+        "m_NominateOnly"      "1"
+        "m_VipOnly"           "0"
+        "m_AdminOnly"         "1"
+        "m_RefundRatio"       "0.5"
+    }
 }

--- a/ZombiEscape/addons/sourcemod/configs/mapdata.kv
+++ b/ZombiEscape/addons/sourcemod/configs/mapdata.kv
@@ -7590,7 +7590,7 @@
         "m_AdminOnly"         "0"
         "m_RefundRatio"       "0.5"
     }
-	"ze_harry_potter_v2_1_csgo"
+    "ze_harry_potter_v2_1_csgo"
     {
         "m_Description"       "哈利波特传说传记"
         "m_Difficulty"        "6"

--- a/ZombiEscape/cfg/sourcemod/map-configs/ze_harry_potter_v2_1_csgo.cfg
+++ b/ZombiEscape/cfg/sourcemod/map-configs/ze_harry_potter_v2_1_csgo.cfg
@@ -63,7 +63,7 @@ ze_infection_sort_by_keephuman_desc "1"
 // 说  明: 尸变比 (人)
 // 最小值: 1
 // 最大值: 32
-zr_infect_mzombie_ratio "6"
+zr_infect_mzombie_ratio "7"
 
 // 说  明: 尸变时传送回出生点 (开关)
 // 最小值: 0
@@ -83,7 +83,7 @@ zr_infect_spawntime_min "10.0"
 // 说  明: 全局击退系数 (%)
 // 最小值: 0.1
 // 最大值: 1.5
-zr_knockback_multi "1.3"
+zr_knockback_multi "1.36"
 
 
 ///
@@ -93,7 +93,7 @@ zr_knockback_multi "1.3"
 // 说  明: 伤害与金钱转化比例 ($)
 // 最小值: 0.1
 // 最大值: 3.0
-ze_damage_zombie_cash "0.9"
+ze_damage_zombie_cash "0.96"
 
 // 说  明: 伤害云点转化比例 (云点)
 // 最小值: 5000.0
@@ -108,12 +108,12 @@ ze_damage_shop_credit "20000"
 // 说  明: 通关所获得的积分 (积分)
 // 最小值: 1
 // 最大值: 30
-ze_credits_pass_round "6"
+ze_credits_pass_round "8"
 
 // 说  明: 通关获得多少云点<人类>
 // 最小值: 1
 // 最大值: 30
-rank_ze_win_points_humans "12"
+rank_ze_win_points_humans "13"
 
 
 ///
@@ -203,7 +203,7 @@ ze_savelevel_multis "0"
 // 说  明: 高爆模式, 0为禁用, 1 = 燃烧, 2 = 减速, 3 = 击退 (开关)
 // 最小值: 0
 // 最大值: 3
-ze_grenade_nade_cfeffect "1"
+ze_grenade_nade_cfeffect "3"
 
 
 ///
@@ -213,7 +213,7 @@ ze_grenade_nade_cfeffect "1"
 // 说  明: 每局最大可购买的Awp数量 (把)
 // 最小值: 1
 // 最大值: 64
-ze_weapons_awp_counts "3"
+ze_weapons_awp_counts "1"
 
 // 说  明: 每局开始时补给的高爆数量 (个)
 // 最小值: 0
@@ -233,7 +233,7 @@ ze_weapons_spawn_decoy "0"
 // 说  明: 每局最多可购买的高爆数量 (个)
 // 最小值: -1
 // 最大值: 15
-ze_weapons_round_hegrenade "7"
+ze_weapons_round_hegrenade "9"
 
 // 说  明: 每局最多可购买的火瓶数量 (个)
 // 最小值: -1
@@ -258,7 +258,7 @@ ze_weapons_round_tagrenade "-1"
 // 说  明: 每局最多可购买的血针数量 (支)
 // 最小值: -1
 // 最大值: 5
-ze_weapons_round_healshot "-1"
+ze_weapons_round_healshot "1"
 
 
 ///
@@ -273,7 +273,7 @@ sm_hunter_leappower "150.0"
 // 说  明: 加速暴发冲力 (%)
 // 最小值: 1.1
 // 最大值: 2.0
-sm_faster_maxspeed "1.6"
+sm_faster_maxspeed "1.5"
 
 // 说  明: 唾液射程 (Unit)
 // 最小值: 100.0
@@ -283,7 +283,7 @@ sm_boomer_distance "300.0"
 // 说  明: 勾搭范围 (Unit)
 // 最小值: 100.0
 // 最大值: 9999.9
-sm_smoker_distance "170.0"
+sm_smoker_distance "160.0"
 
 // 说  明: 跳刀伤害 (Unit)
 // 最小值: 30.0


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_harry_potter_v2_1_csgo
## 为什么要增加/修改这个东西
①半新增地图
②kv仅限8f大型活动图 暂不考虑全服部署(adminonly)
③两年前的参数不适合现阶段ze环境及插件加上现阶段无法调整空击 故优化 后续会跟进调整
④根据守则不因削弱强势方故加强弱势人类方 以免人类技术力过低
⑤该图为十三关大型长征神器高难图 故开放圣光雷和调整道具数量
⑥略微小调僵尸参数继续优化 以应对某些不合地图情理的操作点
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
