### PR TITLE
修改地图参数: ze_aurora_tower_v6_8

### DIFF
--- a/ZombiEscape/cfg/sourcemod/map-configs/ze_aurora_tower_v6_8.cfg
+++ b/ZombiEscape/cfg/sourcemod/map-configs/ze_aurora_tower_v6_8.cfg
@@ -63,7 +63,7 @@ ze_infection_sort_by_keephuman_desc "1"
 // 说  明: 尸变比 (人)
 // 最小值: 1
 // 最大值: 32
-zr_infect_mzombie_ratio "7"
+zr_infect_mzombie_ratio "8"
 
 // 说  明: 尸变时传送回出生点 (开关)
 // 最小值: 0
@@ -73,12 +73,12 @@ zr_infect_mzombie_respawn "1"
 // 说  明: 尸变倒计时<须与zr_infect_spawntime_min同步> (秒)
 // 最小值: 1
 // 最大值: 90
-zr_infect_spawntime_max "10.0"
+zr_infect_spawntime_max "8.0"
 
 // 说  明: 尸变倒计时<须与zr_infect_spawntime_max同步> (秒)
 // 最小值: 1
 // 最大值: 90
-zr_infect_spawntime_min "10.0"
+zr_infect_spawntime_min "8.0"
 
 // 说  明: 全局击退系数 (%)
 // 最小值: 0.1
@@ -138,7 +138,7 @@ ze_bosshp_vscript_creation "0"
 // 说  明: 拾取神器所需的最低云点 (云点)
 // 最小值: 500
 // 最大值: 10000
-ze_newbee_protection_point "500"
+ze_newbee_protection_point "2000"
 
 // 说  明: xXx: DO NOT CHANGE THIS!!!
 // 最小值: 0

--- a/ZombiEscape/cfg/sourcemod/map-configs/ze_aurora_tower_v6_8.cfg
+++ b/ZombiEscape/cfg/sourcemod/map-configs/ze_aurora_tower_v6_8.cfg
@@ -248,12 +248,12 @@ ze_weapons_round_decoy "2"
 // 说  明: 每局最多可购买的屏障数量 (个)
 // 最小值: -1
 // 最大值: 10
-ze_weapons_round_flash "2"
+ze_weapons_round_flash "1"
 
 // 说  明: 每局最多可购买的黑洞数量 (个)
 // 最小值: -1
 // 最大值: 5
-ze_weapons_round_tagrenade "1"
+ze_weapons_round_tagrenade "-1"
 
 // 说  明: 每局最多可购买的血针数量 (支)
 // 最小值: -1


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_aurora_tower_v6_8
## 为什么要增加/修改这个东西
更改为开荒参数，人类Extreme关存在极重要神器，上调云点要求
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
