### PR TITLE
修改地图参数: ze_crazykart_v4

### DIFF
--- a/ZombiEscape/cfg/sourcemod/map-configs/ze_crazykart_v4.cfg
+++ b/ZombiEscape/cfg/sourcemod/map-configs/ze_crazykart_v4.cfg
@@ -48,7 +48,7 @@ mcr_map_extend_times "2"
 // 说  明: 第三人称视角控制 (开关)
 // 最小值: 0
 // 最大值: 1
-store_thirdperson_enabled "0"
+store_thirdperson_enabled "1"
 
 
 ///
@@ -228,7 +228,7 @@ ze_weapons_spawn_molotov "0"
 // 说  明: 每局开始时补给的冰冻数量 (个)
 // 最小值: 0
 // 最大值: 1
-ze_weapons_spawn_decoy "1"
+ze_weapons_spawn_decoy "0"
 
 // 说  明: 每局最多可购买的高爆数量 (个)
 // 最小值: -1
@@ -243,7 +243,7 @@ ze_weapons_round_molotov "1"
 // 说  明: 每局最多可购买的冰冻数量 (个)
 // 最小值: -1
 // 最大值: 10
-ze_weapons_round_decoy "0"
+ze_weapons_round_decoy "-1"
 
 // 说  明: 每局最多可购买的屏障数量 (个)
 // 最小值: -1


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_crazykart_v4
## 为什么要增加/修改这个东西
开放第三人称，不然没法用作者给的指令；实战测试，里世界排名前三名丢道具就会导致炸服，删除开局和商店道具，增加击退。
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
