### PR TITLE
修改地图参数: ze_frostdrake_tower_v1

### DIFF
--- a/ZombiEscape/cfg/sourcemod/map-configs/ze_frostdrake_tower_v1.cfg
+++ b/ZombiEscape/cfg/sourcemod/map-configs/ze_frostdrake_tower_v1.cfg
@@ -238,7 +238,7 @@ ze_weapons_round_hegrenade "8"
 // 说  明: 每局最多可购买的火瓶数量 (个)
 // 最小值: -1
 // 最大值: 10
-ze_weapons_round_molotov "2"
+ze_weapons_round_molotov "1"
 
 // 说  明: 每局最多可购买的冰冻数量 (个)
 // 最小值: -1

--- a/ZombiEscape/cfg/sourcemod/map-configs/ze_frostdrake_tower_v1.cfg
+++ b/ZombiEscape/cfg/sourcemod/map-configs/ze_frostdrake_tower_v1.cfg
@@ -283,7 +283,7 @@ sm_boomer_distance "300.0"
 // 说  明: 勾搭范围 (Unit)
 // 最小值: 100.0
 // 最大值: 9999.9
-sm_smoker_distance "500.0"
+sm_smoker_distance "300.0"
 
 // 说  明: 跳刀伤害 (Unit)
 // 最小值: 30.0


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_frostdrake_tower_v1
## 为什么要增加/修改这个东西
断后图钩子过长，开黑点必抽奖掉人，这个版本根本过不去，同时削弱人类，只给1瓶火
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
