### PR TITLE
修改地图参数: ze_last_man_standing_p3

### DIFF
--- a/ZombiEscape/cfg/sourcemod/map-configs/ze_last_man_standing_p3.cfg
+++ b/ZombiEscape/cfg/sourcemod/map-configs/ze_last_man_standing_p3.cfg
@@ -63,7 +63,7 @@ ze_infection_sort_by_keephuman_desc "0"
 // 说  明: 尸变比 (人)
 // 最小值: 1
 // 最大值: 32
-zr_infect_mzombie_ratio "4"
+zr_infect_mzombie_ratio "5"
 
 // 说  明: 尸变时传送回出生点 (开关)
 // 最小值: 0

--- a/ZombiEscape/cfg/sourcemod/map-configs/ze_last_man_standing_p3.cfg
+++ b/ZombiEscape/cfg/sourcemod/map-configs/ze_last_man_standing_p3.cfg
@@ -63,7 +63,7 @@ ze_infection_sort_by_keephuman_desc "0"
 // 说  明: 尸变比 (人)
 // 最小值: 1
 // 最大值: 32
-zr_infect_mzombie_ratio "6"
+zr_infect_mzombie_ratio "4"
 
 // 说  明: 尸变时传送回出生点 (开关)
 // 最小值: 0
@@ -83,7 +83,7 @@ zr_infect_spawntime_min "30"
 // 说  明: 全局击退系数 (%)
 // 最小值: 0.1
 // 最大值: 1.5
-zr_knockback_multi "1.0"
+zr_knockback_multi "1.1"
 
 
 ///
@@ -113,7 +113,7 @@ ze_credits_pass_round "4"
 // 说  明: 通关获得多少云点<人类>
 // 最小值: 1
 // 最大值: 30
-rank_ze_win_points_humans "6"
+rank_ze_win_points_humans "9"
 
 
 ///
@@ -138,12 +138,12 @@ ze_bosshp_vscript_creation "0"
 // 说  明: 拾取神器所需的最低云点 (云点)
 // 最小值: 500
 // 最大值: 10000
-ze_newbee_protection_point "1500"
+ze_newbee_protection_point "500"
 
 // 说  明: 需要助手以拾取神器
 // 最小值: 0
 // 最大值: 1
-entwatch_require_client "1"
+entwatch_require_client "0"
 
 // 说  明: 允许按E键拾取神器 (开关)
 // 最小值: 0


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_last_man_standing_p3
## 为什么要增加/修改这个东西
由于地图云点和登录器原因，可能会导致地图boss被吞，所以修改参数以防此问题。
根据地图难度和僵尸血量适量修改击退和通关云点及尸变比。
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
