### PR TITLE
修改地图参数: ze_last_man_standing_p3

### DIFF
--- a/ZombiEscape/cfg/sourcemod/map-configs/ze_last_man_standing_p3.cfg
+++ b/ZombiEscape/cfg/sourcemod/map-configs/ze_last_man_standing_p3.cfg
@@ -73,12 +73,12 @@ zr_infect_mzombie_respawn "1"
 // 说  明: 尸变倒计时<须与zr_infect_spawntime_min同步> (秒)
 // 最小值: 1
 // 最大值: 90
-zr_infect_spawntime_max "30"
+zr_infect_spawntime_max "25"
 
 // 说  明: 尸变倒计时<须与zr_infect_spawntime_max同步> (秒)
 // 最小值: 1
 // 最大值: 90
-zr_infect_spawntime_min "30"
+zr_infect_spawntime_min "25"
 
 // 说  明: 全局击退系数 (%)
 // 最小值: 0.1
@@ -138,12 +138,12 @@ ze_bosshp_vscript_creation "0"
 // 说  明: 拾取神器所需的最低云点 (云点)
 // 最小值: 500
 // 最大值: 10000
-ze_newbee_protection_point "1500"
+ze_newbee_protection_point "500"
 
 // 说  明: 需要助手以拾取神器
 // 最小值: 0
 // 最大值: 1
-entwatch_require_client "1"
+entwatch_require_client "0"
 
 // 说  明: 允许按E键拾取神器 (开关)
 // 最小值: 0

--- a/ZombiEscape/cfg/sourcemod/map-entwatch/ze_last_man_standing_p3.cfg
+++ b/ZombiEscape/cfg/sourcemod/map-entwatch/ze_last_man_standing_p3.cfg
@@ -440,5 +440,21 @@
         "hud"               "true"
         "autotransfer"      "true"
     }
+    "27"
+    {
+        "name"              "艾历克斯-墨瑟"
+        "shortname"         "A哥"
+        "team"              "2"
+        "buttonclass"       "func_button"
+        "hasfiltername"     "true"
+        "filtername"        "zombie_boss"
+        "hammerid"          "10339552"
+        "maxamount"         "1"
+        "mode"              "1"
+        "triggerid"         "5588482"
+        "glow"              "false"
+        "hud"               "true"
+        "autotransfer"      "false"
+    }
 
 }


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_last_man_standing_p3
## 为什么要增加/修改这个东西
自动发刀，无法拾取A哥，回滚entwatch。第3关和ex3，打败A哥为主要目的，防止卡关降低神器拾取云点，并关闭需要助手拾取神器
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
