### PR TITLE
修改地图参数: ze_collective_v1_9

### DIFF
--- a/ZombiEscape/cfg/sourcemod/map-configs/ze_collective_v1_9.cfg
+++ b/ZombiEscape/cfg/sourcemod/map-configs/ze_collective_v1_9.cfg
@@ -83,7 +83,7 @@ zr_infect_spawntime_min "12.0"
 // 说  明: 全局击退系数 (%)
 // 最小值: 0.1
 // 最大值: 1.5
-zr_knockback_multi "1.5"
+zr_knockback_multi "1.1"
 
 
 ///
@@ -138,7 +138,7 @@ ze_bosshp_vscript_creation "0"
 // 说  明: 拾取神器所需的最低云点 (云点)
 // 最小值: 500
 // 最大值: 10000
-ze_newbee_protection_point "10000"
+ze_newbee_protection_point "2000"
 
 // 说  明: 需要助手以拾取神器
 // 最小值: 0
@@ -148,7 +148,7 @@ entwatch_require_client "0"
 // 说  明: 允许按E键拾取神器 (开关)
 // 最小值: 0
 // 最大值: 1
-entwatch_allow_use_to_acquire "0"
+entwatch_allow_use_to_acquire "1"
 
 // 说  明: 允许按E键拾取自动识别PhysicsBox (开关)
 // 最小值: 0
@@ -233,27 +233,27 @@ ze_weapons_spawn_hegrenade "1"
 // 说  明: 每局开始时补给的火瓶数量 (个)
 // 最小值: 0
 // 最大值: 1
-ze_weapons_spawn_molotov "1"
+ze_weapons_spawn_molotov "0"
 
 // 说  明: 每局开始时补给的冰冻数量 (个)
 // 最小值: 0
 // 最大值: 1
-ze_weapons_spawn_decoy "1"
+ze_weapons_spawn_decoy "0"
 
 // 说  明: 每局最多可购买的高爆数量 (个)
 // 最小值: -1
 // 最大值: 15
-ze_weapons_round_hegrenade "7"
+ze_weapons_round_hegrenade "15"
 
 // 说  明: 每局最多可购买的火瓶数量 (个)
 // 最小值: -1
 // 最大值: 10
-ze_weapons_round_molotov "1"
+ze_weapons_round_molotov "-1"
 
 // 说  明: 每局最多可购买的冰冻数量 (个)
 // 最小值: -1
 // 最大值: 10
-ze_weapons_round_decoy "2"
+ze_weapons_round_decoy "-1"
 
 // 说  明: 每局最多可购买的屏障数量 (个)
 // 最小值: -1
@@ -263,7 +263,7 @@ ze_weapons_round_flash "1"
 // 说  明: 每局最多可购买的磁暴数量 (个)
 // 最小值: -1
 // 最大值: 5
-ze_weapons_round_smoke "1"
+ze_weapons_round_smoke "-1"
 
 // 说  明: 每局最多可购买的黑洞数量 (个)
 // 最小值: -1


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_collective_v1_9
## 为什么要增加/修改这个东西
后续增加无尽关第6关(infinite)参数，前5关参数降低。有些地图作者要开启EPICK，才能拾取神器，修改EPICK为开启，地图作者v1_9有做保护。降低拾取神器云点。降低全局击退系数。降低雷的购买（火无法扩散，火删除。丢冰影响击退雷的击退，冰删除。增加手雷的购买。删除磁暴雷）。后续如打不过，会回调一点击退
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
