### PR TITLE
修改地图参数: ze_uyuni_v1_6

### DIFF
--- a/ZombiEscape/cfg/sourcemod/map-configs/ze_uyuni_v1_6.cfg
+++ b/ZombiEscape/cfg/sourcemod/map-configs/ze_uyuni_v1_6.cfg
@@ -248,7 +248,7 @@ ze_weapons_round_hegrenade "5"
 // 说  明: 每局最多可购买的火瓶数量 (个)
 // 最小值: -1
 // 最大值: 10
-ze_weapons_round_molotov "2"
+ze_weapons_round_molotov "3"
 
 // 说  明: 每局最多可购买的冰冻数量 (个)
 // 最小值: -1
@@ -283,7 +283,7 @@ ze_weapons_round_healshot "1"
 // 说  明: 闪灵冲刺推力 (Unit)
 // 最小值: 150.0
 // 最大值: 500.0
-sm_hunter_leappower "200.0"
+sm_hunter_leappower "190.0"
 
 // 说  明: 加速暴发冲力 (%)
 // 最小值: 1.1


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_uyuni_v1_6
## 为什么要增加/修改这个东西
因闪灵参数过高,地图拥有ZM黑洞/秒杀/低重力 拐角大飞及低重力超车大飞(低重力可提前触发),人类守点困难僵尸ZM群体加速火瓶不够,因长期带此图目前此图仅通关过一次,且游玩人数不少,做细微调整
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
