### PR TITLE
修改地图参数: ze_uyuni_v1_6

### DIFF
--- a/ZombiEscape/cfg/sourcemod/map-configs/ze_uyuni_v1_6.cfg
+++ b/ZombiEscape/cfg/sourcemod/map-configs/ze_uyuni_v1_6.cfg
@@ -93,7 +93,7 @@ zr_knockback_multi "1.4"
 // 说  明: 伤害与金钱转化比例 ($)
 // 最小值: 0.1
 // 最大值: 3.0
-ze_damage_zombie_cash "0.8"
+ze_damage_zombie_cash "0.9"
 
 // 说  明: 伤害云点转化比例 (云点)
 // 最小值: 9999.0
@@ -243,12 +243,12 @@ ze_weapons_spawn_decoy "1"
 // 说  明: 每局最多可购买的高爆数量 (个)
 // 最小值: -1
 // 最大值: 15
-ze_weapons_round_hegrenade "5"
+ze_weapons_round_hegrenade "6"
 
 // 说  明: 每局最多可购买的火瓶数量 (个)
 // 最小值: -1
 // 最大值: 10
-ze_weapons_round_molotov "2"
+ze_weapons_round_molotov "3"
 
 // 说  明: 每局最多可购买的冰冻数量 (个)
 // 最小值: -1
@@ -283,7 +283,7 @@ ze_weapons_round_healshot "1"
 // 说  明: 闪灵冲刺推力 (Unit)
 // 最小值: 150.0
 // 最大值: 500.0
-sm_hunter_leappower "200.0"
+sm_hunter_leappower "180.0"
 
 // 说  明: 加速暴发冲力 (%)
 // 最小值: 1.1


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_uyuni_v1_6
## 为什么要增加/修改这个东西
僵尸神器拥有低重力闪灵参数过高可直接大飞超车,人类守点神器对抗期间道具较少守点过于困难略微提高人类道具数量及刷钱比例
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
