### PR TITLE
修改地图参数: ze_tenkinoko_welkin_v1_6f

### DIFF
--- a/ZombiEscape/cfg/sourcemod/map-configs/ze_tenkinoko_welkin_v1_6f.cfg
+++ b/ZombiEscape/cfg/sourcemod/map-configs/ze_tenkinoko_welkin_v1_6f.cfg
@@ -113,7 +113,7 @@ ze_credits_pass_round "4"
 // 说  明: 通关获得多少云点<人类>
 // 最小值: 1
 // 最大值: 30
-rank_ze_win_points_humans "11"
+rank_ze_win_points_humans "8"
 
 
 ///


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_tenkinoko_welkin_v1_6f
## 为什么要增加/修改这个东西
由于云点过多，而前三关较为简单，导致第三关结束烂分头子直接离开服务器，导致人数急速下降，每次都走15个左右，不说还以为是炸服
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
