### PR TITLE
修改地图翻译: ze_ancient_wrath_v2_test27_cm1

### DIFF
--- a/ZombiEscape/addons/sourcemod/configs/console_t/ze_ancient_wrath_v2_test27_cm1.txt
+++ b/ZombiEscape/addons/sourcemod/configs/console_t/ze_ancient_wrath_v2_test27_cm1.txt
@@ -18,7 +18,7 @@
 
     "||| A PLAYER HAS PICKED UP C4 |||"
     {
-        "chi" "**炸药5秒后爆炸**"
+        "chi" "**一名玩家已拾取炸药**"
     }
 
     "||| AIRSTRIKE INCOMING |||"
@@ -283,7 +283,7 @@
 
     "||| OH NO THE BRIDGE IS BROKEN! |||"
     {
-        "chi" "**桥梁没有被摧毁**"
+        "chi" "**桥梁已被摧毁**"
     }
 
     "||| POWER IS RESTORED... DOORS OPEN SOON |||"


### PR DESCRIPTION
将ZE地图金字塔翻译文本中不符合对应语句的翻译修改为“一名玩家已拾取炸药”，同时修改“桥梁没有被摧毁”为“桥梁已被摧毁”

## 该PR作用的地图是(仅英文小写)
ze_ancient_wrath_v2_test27_cm1
## 为什么要增加/修改这个东西
修正翻译
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
