### PR TITLE
修改地图参数: ze_castle_of_the_bladekeeper_v1

### DIFF
--- a/ZombiEscape/cfg/sourcemod/map-configs/ze_castle_of_the_bladekeeper_v1.cfg
+++ b/ZombiEscape/cfg/sourcemod/map-configs/ze_castle_of_the_bladekeeper_v1.cfg
@@ -48,7 +48,7 @@ mcr_map_extend_times "2"
 // 说  明: 第三人称视角控制 (开关)
 // 最小值: 0
 // 最大值: 1
-store_thirdperson_enabled "1"
+store_thirdperson_enabled "0"
 
 
 ///


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_castle_of_the_bladekeeper_v1
## 为什么要增加/修改这个东西
动画时用第三人称视角可以随意走动，地图bug，删除第三人称
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
