### PR TITLE
修改地图参数: ze_obj_collapse_b3fix

### DIFF
--- a/ZombiEscape/cfg/sourcemod/map-configs/ze_obj_collapse_b3fix.cfg
+++ b/ZombiEscape/cfg/sourcemod/map-configs/ze_obj_collapse_b3fix.cfg
@@ -33,12 +33,12 @@ mp_roundtime "60.0"
 // 说  明: VIP延长投票 (次)
 // 最小值: 0
 // 最大值: 2
-vips_map_extend_times "1"
+vips_map_extend_times "2"
 
 // 说  明: MCR延长投票 (次)
 // 最小值: 0
 // 最大值: 2
-mcr_map_extend_times "1"
+mcr_map_extend_times "2"
 
 
 ///
@@ -83,7 +83,7 @@ zr_infect_spawntime_min "20.0"
 // 说  明: 全局击退系数 (%)
 // 最小值: 0.1
 // 最大值: 1.5
-zr_knockback_multi "1.3"
+zr_knockback_multi "1.1"
 
 // 说  明: 母体在传送点多少单位附近属于保护距离(u)
 // 最小值: 0.0
@@ -98,7 +98,7 @@ ze_protection_mzombie_distance "256.0"
 // 说  明: 伤害与金钱转化比例 ($)
 // 最小值: 0.1
 // 最大值: 3.0
-ze_damage_zombie_cash "1.0"
+ze_damage_zombie_cash "0.8"
 
 // 说  明: 伤害云点转化比例 (云点)
 // 最小值: 9999.0
@@ -298,7 +298,7 @@ sm_hunter_leappower "160.0"
 // 说  明: 加速暴发冲力 (%)
 // 最小值: 1.1
 // 最大值: 2.0
-sm_faster_maxspeed "1.4"
+sm_faster_maxspeed "1.5"
 
 // 说  明: 唾液射程 (Unit)
 // 最小值: 100.0


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_obj_collapse_b3fix
## 为什么要增加/修改这个东西
根据开荒反馈增加vip地图延长数量，降低击退金钱比，加强加速
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
