### PR TITLE
修改地图参数: ze_obj_series

### DIFF
--- a/ZombiEscape/cfg/sourcemod/map-configs/ze_obj_infiltration_b3.cfg
+++ b/ZombiEscape/cfg/sourcemod/map-configs/ze_obj_infiltration_b3.cfg
@@ -63,7 +63,7 @@ ze_infection_sort_by_keephuman_desc "1"
 // 说  明: 尸变比 (人)
 // 最小值: 1
 // 最大值: 32
-zr_infect_mzombie_ratio "8"
+zr_infect_mzombie_ratio "6"
 
 // 说  明: 尸变时传送回出生点 (开关)
 // 最小值: 0

--- a/ZombiEscape/cfg/sourcemod/map-configs/ze_obj_infiltration_b3.cfg
+++ b/ZombiEscape/cfg/sourcemod/map-configs/ze_obj_infiltration_b3.cfg
@@ -283,7 +283,7 @@ ze_weapons_round_tagrenade "-1"
 // 说  明: 每局最多可购买的血针数量 (支)
 // 最小值: -1
 // 最大值: 8
-ze_weapons_round_healshot "4"
+ze_weapons_round_healshot "7"
 
 
 ///

--- a/ZombiEscape/cfg/sourcemod/map-configs/ze_obj_npst_v1_4.cfg
+++ b/ZombiEscape/cfg/sourcemod/map-configs/ze_obj_npst_v1_4.cfg
@@ -63,7 +63,7 @@ ze_infection_sort_by_keephuman_desc "1"
 // 说  明: 尸变比 (人)
 // 最小值: 1
 // 最大值: 32
-zr_infect_mzombie_ratio "8"
+zr_infect_mzombie_ratio "6"
 
 // 说  明: 尸变时传送回出生点 (开关)
 // 最小值: 0

--- a/ZombiEscape/cfg/sourcemod/map-configs/ze_obj_npst_v1_4.cfg
+++ b/ZombiEscape/cfg/sourcemod/map-configs/ze_obj_npst_v1_4.cfg
@@ -98,7 +98,7 @@ ze_protection_mzombie_distance "256.0"
 // 说  明: 伤害与金钱转化比例 ($)
 // 最小值: 0.1
 // 最大值: 3.0
-ze_damage_zombie_cash "0.7"
+ze_damage_zombie_cash "0.8"
 
 // 说  明: 伤害云点转化比例 (云点)
 // 最小值: 9999.0
@@ -283,7 +283,7 @@ ze_weapons_round_tagrenade "-1"
 // 说  明: 每局最多可购买的血针数量 (支)
 // 最小值: -1
 // 最大值: 8
-ze_weapons_round_healshot "6"
+ze_weapons_round_healshot "7"
 
 
 ///

--- a/ZombiEscape/cfg/sourcemod/map-configs/ze_obj_rescape_v1.cfg
+++ b/ZombiEscape/cfg/sourcemod/map-configs/ze_obj_rescape_v1.cfg
@@ -63,7 +63,7 @@ ze_infection_sort_by_keephuman_desc "1"
 // 说  明: 尸变比 (人)
 // 最小值: 1
 // 最大值: 32
-zr_infect_mzombie_ratio "8"
+zr_infect_mzombie_ratio "6"
 
 // 说  明: 尸变时传送回出生点 (开关)
 // 最小值: 0

--- a/ZombiEscape/cfg/sourcemod/map-configs/ze_obj_rescape_v1.cfg
+++ b/ZombiEscape/cfg/sourcemod/map-configs/ze_obj_rescape_v1.cfg
@@ -283,7 +283,7 @@ ze_weapons_round_tagrenade "-1"
 // 说  明: 每局最多可购买的血针数量 (支)
 // 最小值: -1
 // 最大值: 8
-ze_weapons_round_healshot "6"
+ze_weapons_round_healshot "7"
 
 
 ///


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_obj_rescape_v1/ze_obj_npst_v1_4/ze_obj_infiltration_b3
## 为什么要增加/修改这个东西
根据通关率及难度增加母体数量，平衡平均难度。统一打钱比与血针数量
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
